### PR TITLE
Makefile: set LD_LIBRARY_PATH before calling executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,12 @@ uninstall:
 
 example: reset sharedlib
 	$(CXX) src/pmemkv_example.cc -o pmemkv_example $(USE_PMEMKV) $(CXX_FLAGS)
-	PMEM_IS_PMEM_FORCE=1 ./pmemkv_example
+	LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH} PMEM_IS_PMEM_FORCE=1 ./pmemkv_example
 
 stress: reset sharedlib
 	$(CXX) src/pmemkv_stress.cc -o pmemkv_stress -DNDEBUG $(USE_PMEMKV) $(CXX_FLAGS)
-	PMEM_IS_PMEM_FORCE=1 ./pmemkv_stress
+	LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH} PMEM_IS_PMEM_FORCE=1 ./pmemkv_stress
 
 test: reset sharedlib
 	$(CXX) src/pmemkv_test.cc -o pmemkv_test $(USE_PMEMKV) $(USE_GTEST) $(CXX_FLAGS)
-	PMEM_IS_PMEM_FORCE=1 ./pmemkv_test
+	LD_LIBRARY_PATH=.:${LD_LIBRARY_PATH} PMEM_IS_PMEM_FORCE=1 ./pmemkv_test


### PR DESCRIPTION
Apparently ld.so doesn't necesseraly look for shared objects in the same
directory as the executable. This can result in such errors:

```
./pmemkv_example: error while loading shared libraries: libpmemkv.so: cannot open shared object file: No such file or directory
make: *** [Makefile:30: example] Error 127
```

Looking at ldd output:

```
$ ldd pmemkv_example
        linux-vdso.so.1 (0x00007ffc905e6000)
        libpmemkv.so => not found
        libdl.so.2 => /usr/lib/libdl.so.2 (0x00007fb66a1ff000)
        libpthread.so.0 => /usr/lib/libpthread.so.0 (0x00007fb669fe1000)
        libstdc++.so.6 => /usr/lib/libstdc++.so.6 (0x00007fb669c59000)
        libm.so.6 => /usr/lib/libm.so.6 (0x00007fb669946000)
        libgcc_s.so.1 => /usr/lib/libgcc_s.so.1 (0x00007fb66972f000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007fb66938b000)
        /lib64/ld-linux-x86-64.so.2 (0x00007fb66a403000)
```