### PR TITLE
Fixing issues on Getting wrong value when a binary value contains null character.

### DIFF
--- a/src/engines/kvtree2.cc
+++ b/src/engines/kvtree2.cc
@@ -129,7 +129,7 @@ KVStatus KVTree::Get(const string& key, string* value) {
                 if (leafnode->keys[slot].compare(key) == 0) {
                     auto kv = leafnode->leaf->slots[slot].get_ro();
                     LOG("   found value, slot=" << slot << ", size=" << to_string(kv.valsize()));
-                    value->append(kv.val());
+                    value->append(kv.val(), kv.valsize());
                     return OK;
                 }
             }

--- a/tests/engines/kvtree_test.cc
+++ b/tests/engines/kvtree_test.cc
@@ -135,9 +135,11 @@ TEST_F(KVTest, BinaryKeyTest) {
 }
 
 TEST_F(KVTest, BinaryValueTest) {
-    ASSERT_TRUE(kv->Put("key1", string("A\0B\0\0C", 3)) == OK) << pmemobj_errormsg();
-    string value;
-    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "A\0B\0\0C");
+    string value("A\0B\0\0C", 6);
+    ASSERT_TRUE(kv->Put("key1", value) == OK) << pmemobj_errormsg();
+    string value_out;
+    ASSERT_TRUE(kv->Get("key1", &value_out) == OK && 
+                memcmp(&value[0], &value_out[0], 6) == 0);
     Analyze();
     ASSERT_EQ(analysis.leaf_empty, 0);
     ASSERT_EQ(analysis.leaf_prealloc, 0);


### PR DESCRIPTION
The current use of append function in the implementation of Get for kvtree2 is not null character friendly... This patch fixes that and binary value test.