### PR TITLE
Making previously written binary key safe after db restarts.

### DIFF
--- a/src/engines/kvtree2.cc
+++ b/src/engines/kvtree2.cc
@@ -412,7 +412,7 @@ void KVTree::Recover() {
             } else if (max_key.compare(0, string::npos, kvslot.key(), kvslot.get_ks()) < 0) {
                 max_key = string(kvslot.key(), kvslot.get_ks());
             }
-            leafnode->keys[slot] = key;
+            leafnode->keys[slot] = string(key, kvslot.get_ks());
         }
 
         // use highest sorting key to decide how to recover the leaf


### PR DESCRIPTION
Otherwise, when db restarts, getting a key that contains null character would fail... 

This is only for kvtree2 engine... not sure about other engines though...