### PR TITLE
Fix poolset support (part 2)

### DIFF
--- a/.poolset.example
+++ b/.poolset.example
@@ -1,0 +1,2 @@
+PMEMPOOLSET
+1GB /dev/shm/pmemkv

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -185,11 +185,10 @@ ll /dev/da*
 crw------- 1 root root 238, 0 Jun  8 11:38 /dev/dax2.0
 ```
 
-Next clear and initialize the DAX device: (using chardev from previous step)
+Next clear the DAX device: (using chardev from previous step)
 
 ```
 pmempool rm --verbose /dev/dax2.0
-pmempool create --layout pmemkv obj /dev/dax2.0
 ```
 
 Now pass the DAX device as a parameter to `pmemkv` like this:
@@ -265,12 +264,6 @@ First create a pool set descriptor:  (`~/pmemkv.poolset` in this example)
 PMEMPOOLSET
 1000M /dev/shm/pmemkv1
 1000M /dev/shm/pmemkv2
-```
-
-Next initialize the pool set:
-
-```
-pmempool create --layout pmemkv obj ~/pmemkv.poolset
 ```
 
 Now pass the pool set as a parameter to `pmemkv` like this:

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,9 @@ uninstall:
 
 bench: configure reset
 	cd ./bin && make pmemkv_bench
-	PMEM_IS_PMEM_FORCE=1 ./bin/pmemkv_bench --db=/dev/shm/pmemkv --db_size_in_gb=1 --histogram=1
+	cp .poolset.example /dev/shm/pmemkv.poolset
+	PMEM_IS_PMEM_FORCE=1 ./bin/pmemkv_bench --db=/dev/shm/pmemkv.poolset --histogram=1
+	rm -rf /dev/shm/pmemkv.poolset
 	rm -rf /dev/shm/pmemkv
 
 example: configure reset

--- a/src/engines/btree.cc
+++ b/src/engines/btree.cc
@@ -49,22 +49,30 @@ using pmem::detail::conditional_add_to_tx;
 namespace pmemkv {
 namespace btree {
 
-BTreeEngine::BTreeEngine(const string& path, const size_t size) {
-    if ((access(path.c_str(), F_OK) != 0) && (size > 0)) {
-        LOG("Creating filesystem pool, path=" << path << ", size=" << to_string(size));
-        pmpool = pool<RootData>::create(path.c_str(), LAYOUT, size, S_IRWXU);
-    } else {
-        LOG("Opening pool, path=" << path);
-        pmpool = pool<RootData>::open(path.c_str(), LAYOUT);
-    }
+BTreeEngine::BTreeEngine(const string& path, const size_t size, const Options options) {
+    OpenCommon(path, size, options);
     Recover();
     LOG("Opened ok");
 }
 
-BTreeEngine::~BTreeEngine() {
-    LOG("Closing");
+void BTreeEngine::Open(const string& path) {
+    LOG("Opening pool, path=" << path);
+    pmpool = pool<RootData>::open(path.c_str(), LAYOUT);
+}
+
+void BTreeEngine::Create(const string& path, const size_t size) {
+    LOG("Creating pool, path=" << path << ", size=" << to_string(size));
+    pmpool = pool<RootData>::create(path.c_str(), LAYOUT, size, S_IRWXU);
+}
+
+void BTreeEngine::Close() {
+    LOG("Closing pool");
     pmpool.close();
     LOG("Closed ok");
+}
+
+BTreeEngine::~BTreeEngine() {
+    Close();
 }
 
 KVStatus BTreeEngine::Get(const int32_t limit, const int32_t keybytes, int32_t* valuebytes,

--- a/src/engines/btree.h
+++ b/src/engines/btree.h
@@ -57,7 +57,9 @@ class BTreeEngine : public KVEngine {
     BTreeEngine(const BTreeEngine&);
     void operator=(const BTreeEngine&);
   public:
-    BTreeEngine(const string& path, size_t size);               // default constructor
+    BTreeEngine(const string& path,                             // default constructor
+                size_t size,
+                Options options);
     ~BTreeEngine();                                             // default destructor
 
     string Engine() final { return ENGINE; }                    // engine identifier
@@ -71,6 +73,11 @@ class BTreeEngine : public KVEngine {
     KVStatus Put(const string& key,                             // copy value from std::string
                  const string& value) final;
     KVStatus Remove(const string& key) final;                   // remove value for key
+  protected:
+    void Open(const string& path);                              // open persistent pool
+    void Create(const string& path,                             // create persistent pool
+                size_t size);
+    void Close();                                               // close persistent pool
   private:
     void Recover();
 

--- a/src/engines/kvtree.h
+++ b/src/engines/kvtree.h
@@ -118,7 +118,9 @@ struct KVTreeAnalysis {                                    // tree analysis stru
 
 class KVTree : public KVEngine {                           // hybrid B+ tree engine
   public:
-    KVTree(const string& path, size_t size);               // default constructor
+    KVTree(const string& path,                             // default constructor
+           size_t size,
+           Options options);
     ~KVTree();                                             // default destructor
 
     string Engine() final { return ENGINE; }               // engine identifier
@@ -135,6 +137,11 @@ class KVTree : public KVEngine {                           // hybrid B+ tree eng
 
     void Analyze(KVTreeAnalysis& analysis);                // report on internal state & stats
   protected:
+    void Open(const string& path);                         // open persistent pool
+    void Create(const string& path,                        // create persistent pool
+                size_t size);
+    void Close();                                          // close persistent pool
+
     KVLeafNode* LeafSearch(const string& key);             // find node for key
     void LeafFillEmptySlot(KVLeafNode* leafnode,           // write first unoccupied slot found
                            uint8_t hash,

--- a/src/engines/kvtree2.cc
+++ b/src/engines/kvtree2.cc
@@ -44,22 +44,30 @@
 namespace pmemkv {
 namespace kvtree2 {
 
-KVTree::KVTree(const string& path, const size_t size) : pmpath(path) {
-    if ((access(path.c_str(), F_OK) != 0) && (size > 0)) {
-        LOG("Creating filesystem pool, path=" << path << ", size=" << to_string(size));
-        pmpool = pool<KVRoot>::create(path.c_str(), LAYOUT, size, S_IRWXU);
-    } else {
-        LOG("Opening pool, path=" << path);
-        pmpool = pool<KVRoot>::open(path.c_str(), LAYOUT);
-    }
+KVTree::KVTree(const string& path, const size_t size, const Options options) : pmpath(path) {
+    OpenCommon(path, size, options);
     Recover();
     LOG("Opened ok");
 }
 
-KVTree::~KVTree() {
-    LOG("Closing");
+void KVTree::Open(const string& path) {
+    LOG("Opening pool, path=" << path);
+    pmpool = pool<KVRoot>::open(path.c_str(), LAYOUT);
+}
+
+void KVTree::Create(const string& path, const size_t size) {
+    LOG("Creating pool, path=" << path << ", size=" << to_string(size));
+    pmpool = pool<KVRoot>::create(path.c_str(), LAYOUT, size, S_IRWXU);
+}
+
+void KVTree::Close() {
+    LOG("Closing pool");
     pmpool.close();
     LOG("Closed ok");
+}
+
+KVTree::~KVTree() {
+    Close();
 }
 
 // ===============================================================================================

--- a/src/engines/kvtree2.h
+++ b/src/engines/kvtree2.h
@@ -131,7 +131,9 @@ struct KVTreeAnalysis {                                    // tree analysis stru
 
 class KVTree : public KVEngine {                           // hybrid B+ tree engine
   public:
-    KVTree(const string& path, size_t size);               // default constructor
+    KVTree(const string& path,                             // default constructor
+           size_t size,
+           Options options);
     ~KVTree();                                             // default destructor
 
     string Engine() final { return ENGINE; }               // engine identifier
@@ -148,6 +150,11 @@ class KVTree : public KVEngine {                           // hybrid B+ tree eng
 
     void Analyze(KVTreeAnalysis& analysis);                // report on internal state & stats
   protected:
+    void Open(const string& path);                         // path to persistent pool
+    void Create(const string& path,                        // path to persistent pool
+                size_t size);                              // size used when creating pool
+    void Close();
+
     KVLeafNode* LeafSearch(const string& key);             // find node for key
     void LeafFillEmptySlot(KVLeafNode* leafnode,           // write first unoccupied slot found
                            uint8_t hash,

--- a/src/pmemkv_bench.cc
+++ b/src/pmemkv_bench.cc
@@ -33,6 +33,9 @@
 #include <sys/types.h>
 #include <cstdio>
 #include <cstdlib>
+
+#include <libpmempool.h>
+
 #include "leveldb/env.h"
 #include "port/port_posix.h"
 #include "histogram.h"
@@ -390,11 +393,9 @@ public:
                     pmemkv::KVEngine::Close(kv_);
                     kv_ = NULL;
                 }
-                if (FLAGS_db_size_in_gb > 0) {
-                    auto start = g_env->NowMicros();
-                    std::remove(FLAGS_db);
-                    fprintf(stdout, "%-12s : %11.3f millis/op;\n", "removed", ((g_env->NowMicros() - start) * 1e-3));
-                }
+                auto start = g_env->NowMicros();
+                pmempool_rm(FLAGS_db, 0);
+                fprintf(stdout, "%-12s : %11.3f millis/op;\n", "removed", ((g_env->NowMicros() - start) * 1e-3));
             }
 
             if (kv_ == NULL) {

--- a/tests/engines/btree_test.cc
+++ b/tests/engines/btree_test.cc
@@ -31,8 +31,13 @@
  */
 
 #include "gtest/gtest.h"
+
+#include <libpmempool.h>
+
+#include "../../src/pmemkv.h"
 #include "../../src/engines/btree.h"
 
+using namespace pmemkv;
 using namespace pmemkv::btree;
 
 const string PATH = "/dev/shm/pmemkv";
@@ -45,7 +50,7 @@ public:
     BTreeEngine* kv;
 
     BTreeEngineBaseTest() {
-        std::remove(PATH.c_str());
+        pmempool_rm(PATH.c_str(), 0);
         Open();
     }
 
@@ -60,7 +65,9 @@ public:
 
 protected:
     void Open() {
-        kv = new BTreeEngine(PATH, POOL_SIZE);
+        KVEngine::Options options;
+        options.create_if_missing = true;
+        kv = new BTreeEngine(PATH, POOL_SIZE, options);
     }
 };
 


### PR DESCRIPTION
- introduce open options:
	- ```error_if_exists``` - raise error if persistent pool exists
	- ```create_if_missing``` - create persistent pool if it is missing
- pmemkv_bench
	- use ```pmempool_rm``` instead of ```std::remove```
	- remove ```db_size_in_gb == 0``` special value
- *_test
	- use ```pmempool_rm``` instead of ```std::remove```
	- introduce open options tests
		- FailsToOpenNonExistingInstanceTest
			- set ```create_if_missing = false```
			- try to open KVTree engine
			- should raise error
		- FailsByOpeningUnexpectedlyExistingInstanceTest
			- set ```create_if_missing = true```
			- open KVTree engine what should create persistent pool
			- close KVTree engine
			- set ```create_if_missing = false```
			- set ```error_if_exists = true```
			- try to open KVTree engine
			- should raise error
- add poolset test to Makefile