### PR TITLE
btree: implement delete operation in btree engine

### DIFF
--- a/src/engines/btree.cc
+++ b/src/engines/btree.cc
@@ -109,7 +109,11 @@ KVStatus BTreeEngine::Put(const string& key, const string& value) {
 
 KVStatus BTreeEngine::Remove(const string& key) {
     LOG("Remove key=" << key);
-    return FAILED;
+    size_t result = my_btree->erase(key);
+    if (result == 1) {
+        return OK;
+    } 
+    return NOT_FOUND;
 }
 
 void BTreeEngine::Recover() {


### PR DESCRIPTION
Initial changes to support delete operation in btree engine.
Current implementation is incomplete. Right now, btree does not support
leaf node merge operation when amount of elements less than half of the leaf node
capacity.

Ref:  pmemkv/issue#82