### PR TITLE
Adding new engines based on memkind

### DIFF
--- a/src/engines/std_map.cc
+++ b/src/engines/std_map.cc
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "std_map.h"
+
+#include <iostream>
+
+#define DO_LOG 0
+#define LOG(msg) if (DO_LOG) std::cout << "[std_map] " << msg << "\n"
+
+namespace pmemkv {
+namespace std_map {
+
+StdMap::StdMap(const string& path, size_t size) : kv_allocator(path, size), ch_allocator(kv_allocator),
+    pmem_kv_container(std::scoped_allocator_adaptor<kv_allocator_t>(kv_allocator)) { LOG("Opened ok"); }
+
+StdMap::~StdMap() { LOG("Closed ok"); }
+
+int64_t StdMap::Count() {
+    int64_t result = 0;
+    for (auto& iterator : pmem_kv_container) result++;
+    return result;
+}
+
+KVStatus StdMap::Exists(const string& key) {
+    LOG("Exists for key=" << key);
+    const bool result = pmem_kv_container.find(pmem_string(key.c_str(), key.size(), ch_allocator)) != pmem_kv_container.end();
+    return (result ? OK : NOT_FOUND);
+}
+
+void StdMap::Each(void* context, KVEachCallback* callback) {
+    LOG("Each");
+    for (auto& iterator : pmem_kv_container) {
+        (*callback)(context, (int32_t)iterator.first.size(), (int32_t)iterator.second.size(),
+                iterator.first.c_str(), iterator.second.c_str());
+    }
+}
+
+void StdMap::Get(void* context, const string& key, KVGetCallback* callback) {
+    LOG("Get key=" << key);
+    const auto pos = pmem_kv_container.find(pmem_string(key.c_str(), key.size(), ch_allocator));
+    if (pos == pmem_kv_container.end()) {
+        LOG("  key not found");
+        return;
+    }
+    (*callback)(context, (int32_t) pos->second.size(), pos->second.c_str());
+}
+
+KVStatus StdMap::Put(const string& key, const string& value) {
+    LOG("Put key=" << key << ", value.size=" << to_string(value.size()));    
+    pmem_kv_container[pmem_string(key.c_str(), key.size(), ch_allocator)] = pmem_string(value.c_str(), value.size(), ch_allocator);    
+    return OK;
+}
+
+KVStatus StdMap::Remove(const string& key) {
+    LOG("Remove key=" << key);
+    size_t erased = pmem_kv_container.erase(pmem_string(key.c_str(), key.size(), ch_allocator));
+    if (erased == 1) {
+        return OK;
+    }
+    return NOT_FOUND;
+}
+
+} // namespace std_map
+} // namespace pmemkv

--- a/src/engines/std_map.h
+++ b/src/engines/std_map.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "../pmemkv.h"
+#include "pmem_allocator.h"
+#include <map>
+#include <string>
+#include <scoped_allocator>
+
+namespace pmemkv {
+namespace std_map {
+
+const string ENGINE = "std_map";                         // engine identifier
+
+class StdMap : public KVEngine {
+
+    typedef pmem::allocator<char> ch_allocator_t;
+    typedef std::basic_string<char, std::char_traits<char>, ch_allocator_t > pmem_string;
+    typedef pmem::allocator<std::pair<pmem_string, pmem_string> > kv_allocator_t;
+    typedef std::map<pmem_string, pmem_string, std::less<pmem_string>, std::scoped_allocator_adaptor<kv_allocator_t > > map_t;
+
+    kv_allocator_t kv_allocator;
+    ch_allocator_t ch_allocator;
+    map_t pmem_kv_container;
+
+public:
+    StdMap(const string& path, size_t size);           // default constructor
+    ~StdMap();                                          // default destructor
+
+    string Engine() final { return ENGINE; }               // engine identifier
+
+    int64_t Count() final;                                 // count all keys
+
+    using KVEngine::Each;                                  // iterate over all keys & values
+    void Each(void* context,                               // (with context)
+            KVEachCallback* callback) final;
+
+    KVStatus Exists(const string& key) final;              // does key have a value?
+
+    using KVEngine::Get;                                   // pass value to callback
+    void Get(void* context,                                // (with context)
+            const string& key,
+            KVGetCallback* callback) final;
+
+    KVStatus Put(const string& key,                        // store key and value
+            const string& value) final;
+    KVStatus Remove(const string& key) final;              // remove value for key
+};
+
+} // namespace std_map
+} // namespace pmemkv

--- a/src/engines/tbb_hash_map.cc
+++ b/src/engines/tbb_hash_map.cc
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "tbb_hash_map.h"
+
+#include <iostream>
+
+#define DO_LOG 0
+#define LOG(msg) if (DO_LOG) std::cout << "[tbb_hash_map] " << msg << "\n"
+
+namespace pmemkv {
+namespace tbb_hash_map {
+
+TbbHashMap::TbbHashMap(const string& path, size_t size) : kv_allocator(path, size), ch_allocator(kv_allocator),
+    pmem_kv_container(std::scoped_allocator_adaptor<kv_allocator_t>(kv_allocator)) { LOG("Opened ok"); }
+
+TbbHashMap::~TbbHashMap() { LOG("Closed ok"); }
+
+int64_t TbbHashMap::Count() {
+    int64_t result = 0;
+    for (auto& iterator : pmem_kv_container) result++; 
+    return result;
+}
+
+KVStatus TbbHashMap::Exists(const string& key) {
+    LOG("Exists for key=" << key);
+    map_t::const_accessor result;
+    const bool result_found = pmem_kv_container.find(result, pmem_string(key.c_str(), key.size(), ch_allocator));
+    return (result_found ? OK : NOT_FOUND);
+}
+
+void TbbHashMap::Each(void* context, KVEachCallback* callback) {
+    LOG("Each");
+    for (auto& iterator : pmem_kv_container) {
+        (*callback)(context, (int32_t)iterator.first.size(), (int32_t)iterator.second.size(),
+                iterator.first.c_str(), iterator.second.c_str());
+    }
+}
+
+void TbbHashMap::Get(void* context, const string& key, KVGetCallback* callback) {
+    LOG("Get key=" << key);
+    map_t::const_accessor result;
+    const bool result_found = pmem_kv_container.find(result, pmem_string(key.c_str(), key.size(), ch_allocator));
+    if (!result_found) {
+        LOG("  key not found");
+        return;
+    }
+    (*callback)(context, (int32_t) result->second.size(), result->second.c_str());
+}
+
+KVStatus TbbHashMap::Put(const string& key, const string& value) {    
+    LOG("Put key=" << key << ", value.size=" << to_string(value.size()));    
+    map_t::value_type kv_pair { pmem_string(key.c_str(), key.size(), ch_allocator), pmem_string(value.c_str(), value.size(), ch_allocator) };    
+    bool result = pmem_kv_container.insert(kv_pair);
+
+    if (!result) {
+        map_t::accessor result_found;
+        pmem_kv_container.find(result_found, kv_pair.first);
+        result_found->second = kv_pair.second;
+    }
+
+    return OK;
+}
+
+KVStatus TbbHashMap::Remove(const string& key) {
+    LOG("Remove key=" << key);
+    size_t erased = pmem_kv_container.erase(pmem_string(key.c_str(), key.size(), ch_allocator));
+    if (erased == 1) {
+        return OK;
+    }
+    return NOT_FOUND;
+}
+
+} // namespace tbb_hash_map
+} // namespace pmemkv

--- a/src/engines/tbb_hash_map.h
+++ b/src/engines/tbb_hash_map.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "../pmemkv.h"
+#include "pmem_allocator.h"
+#include <string>
+#include <scoped_allocator>
+#include <tbb/concurrent_hash_map.h>
+
+namespace pmemkv {
+namespace tbb_hash_map {
+
+const string ENGINE = "tbb_hash_map";                         // engine identifier
+
+class TbbHashMap : public KVEngine {
+
+    typedef pmem::allocator<char> ch_allocator_t;
+    typedef std::basic_string<char, std::char_traits<char>, ch_allocator_t > pmem_string;
+    typedef pmem::allocator<std::pair<pmem_string, pmem_string> > kv_allocator_t;
+    typedef tbb::concurrent_hash_map<pmem_string, pmem_string, tbb::tbb_hash_compare<pmem_string>, std::scoped_allocator_adaptor<kv_allocator_t > > map_t;
+
+    kv_allocator_t kv_allocator;
+    ch_allocator_t ch_allocator;
+    map_t pmem_kv_container;
+
+public:
+    TbbHashMap(const string& path, size_t size);           // default constructor
+    ~TbbHashMap();                                          // default destructor
+
+    string Engine() final { return ENGINE; }               // engine identifier
+
+    int64_t Count() final;                                 // count all keys
+
+    using KVEngine::Each;                                  // iterate over all keys & values
+    void Each(void* context,                               // (with context)
+            KVEachCallback* callback) final;
+
+    KVStatus Exists(const string& key) final;              // does key have a value?
+
+    using KVEngine::Get;                                   // pass value to callback
+    void Get(void* context,                                // (with context)
+            const string& key,
+            KVGetCallback* callback) final;
+
+    KVStatus Put(const string& key,                        // store key and value
+            const string& value) final;
+    KVStatus Remove(const string& key) final;              // remove value for key
+};
+
+} // namespace tbb_hash_map
+} // namespace pmemkv

--- a/tests/engines/std_map_test.cc
+++ b/tests/engines/std_map_test.cc
@@ -1,0 +1,325 @@
+/*
+ * Copyright 2017-2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "../../src/engines/std_map.h"
+#include "../../src/pmemkv.h"
+
+using namespace pmemkv::std_map;
+
+class StdMapTest : public testing::Test {
+public:
+    StdMap* kv;
+    StdMapTest() {
+        kv = new StdMap("/dev/shm", 1024 * 1024 * 1024);
+    }
+
+    ~StdMapTest() {
+        delete kv;
+
+    }
+};
+
+TEST_F(StdMapTest, SimpleTest) {
+    string value;
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Get("key1", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "value1");
+}
+
+TEST_F(StdMapTest, BinaryKeyTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("a"));
+    ASSERT_TRUE(kv->Put("a", "should_not_change") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("a"));
+    string key1 = string("a\0b", 3);
+    ASSERT_TRUE(!kv->Exists(key1));
+    ASSERT_TRUE(kv->Put(key1, "stuff") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Exists("a"));
+    ASSERT_TRUE(kv->Exists(key1));
+    string value;
+    ASSERT_TRUE(kv->Get(key1, &value) == OK);
+    ASSERT_EQ(value, "stuff");
+    string value2;
+    ASSERT_TRUE(kv->Get("a", &value2) == OK);
+    ASSERT_EQ(value2, "should_not_change");
+    ASSERT_TRUE(kv->Remove(key1) == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("a"));
+    ASSERT_TRUE(!kv->Exists(key1));
+    string value3;
+    ASSERT_TRUE(kv->Get(key1, &value3) == NOT_FOUND);
+    ASSERT_TRUE(kv->Get("a", &value3) == OK && value3 == "should_not_change");
+}
+
+TEST_F(StdMapTest, BinaryValueTest) {
+    string value("A\0B\0\0C", 6);
+    ASSERT_TRUE(kv->Put("key1", value) == OK);
+    string value_out;
+    ASSERT_TRUE(kv->Get("key1", &value_out) == OK && memcmp(&value[0], &value_out[0], 6) == 0);
+}
+
+TEST_F(StdMapTest, EmptyKeyTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("", "empty") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put(" ", "single-space") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Put("\t\t", "two-tab") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    string value1;
+    string value2;
+    string value3;
+    ASSERT_TRUE(kv->Exists(""));
+    ASSERT_TRUE(kv->Get("", &value1) == OK && value1 == "empty");
+    ASSERT_TRUE(kv->Exists(" "));
+    ASSERT_TRUE(kv->Get(" ", &value2) == OK && value2 == "single-space");
+    ASSERT_TRUE(kv->Exists("\t\t"));
+    ASSERT_TRUE(kv->Get("\t\t", &value3) == OK && value3 == "two-tab");
+}
+
+TEST_F(StdMapTest, EmptyValueTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("empty", "") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("single-space", " ") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Put("two-tab", "\t\t") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    string value1;
+    string value2;
+    string value3;
+    ASSERT_TRUE(kv->Get("empty", &value1) == OK && value1 == "");
+    ASSERT_TRUE(kv->Get("single-space", &value2) == OK && value2 == " ");
+    ASSERT_TRUE(kv->Get("two-tab", &value3) == OK && value3 == "\t\t");
+}
+
+TEST_F(StdMapTest, GetAppendToExternalValueTest) {
+    ASSERT_TRUE(kv->Put("key1", "cool") == OK);
+    string value = "super";
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "supercool");
+}
+
+TEST_F(StdMapTest, GetHeadlessTest) {
+    ASSERT_TRUE(!kv->Exists("waldo"));
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(StdMapTest, GetMultipleTest) {
+    ASSERT_TRUE(kv->Put("abc", "A1") == OK);
+    ASSERT_TRUE(kv->Put("def", "B2") == OK);
+    ASSERT_TRUE(kv->Put("hij", "C3") == OK);
+    ASSERT_TRUE(kv->Put("jkl", "D4") == OK);
+    ASSERT_TRUE(kv->Put("mno", "E5") == OK);
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Exists("abc"));
+    string value1;
+    ASSERT_TRUE(kv->Get("abc", &value1) == OK && value1 == "A1");
+    ASSERT_TRUE(kv->Exists("def"));
+    string value2;
+    ASSERT_TRUE(kv->Get("def", &value2) == OK && value2 == "B2");
+    ASSERT_TRUE(kv->Exists("hij"));
+    string value3;
+    ASSERT_TRUE(kv->Get("hij", &value3) == OK && value3 == "C3");
+    ASSERT_TRUE(kv->Exists("jkl"));
+    string value4;
+    ASSERT_TRUE(kv->Get("jkl", &value4) == OK && value4 == "D4");
+    ASSERT_TRUE(kv->Exists("mno"));
+    string value5;
+    ASSERT_TRUE(kv->Get("mno", &value5) == OK && value5 == "E5");
+}
+
+TEST_F(StdMapTest, GetMultiple2Test) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Put("key2", "value2") == OK);
+    ASSERT_TRUE(kv->Put("key3", "value3") == OK);
+    ASSERT_TRUE(kv->Remove("key2") == OK);
+    ASSERT_TRUE(kv->Put("key3", "VALUE3") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    string value1;
+    ASSERT_TRUE(kv->Get("key1", &value1) == OK && value1 == "value1");
+    string value2;
+    ASSERT_TRUE(kv->Get("key2", &value2) == NOT_FOUND);
+    string value3;
+    ASSERT_TRUE(kv->Get("key3", &value3) == OK && value3 == "VALUE3");
+}
+
+TEST_F(StdMapTest, GetNonexistentTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(!kv->Exists("waldo"));
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(StdMapTest, PutTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+
+    string value;
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "value1");
+
+    string new_value;
+    ASSERT_TRUE(kv->Put("key1", "VALUE1") == OK);           // same size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value) == OK && new_value == "VALUE1");
+
+    string new_value2;
+    ASSERT_TRUE(kv->Put("key1", "new_value") == OK);        // longer size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value2) == OK && new_value2 == "new_value");
+
+    string new_value3;
+    ASSERT_TRUE(kv->Put("key1", "?") == OK);                // shorter size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value3) == OK && new_value3 == "?");
+}
+
+TEST_F(StdMapTest, PutKeysOfDifferentSizesTest) {
+    string value;
+    ASSERT_TRUE(kv->Put("123456789ABCDE", "A") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("123456789ABCDE", &value) == OK && value == "A");
+
+    string value2;
+    ASSERT_TRUE(kv->Put("123456789ABCDEF", "B") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Get("123456789ABCDEF", &value2) == OK && value2 == "B");
+
+    string value3;
+    ASSERT_TRUE(kv->Put("12345678ABCDEFG", "C") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    ASSERT_TRUE(kv->Get("12345678ABCDEFG", &value3) == OK && value3 == "C");
+
+    string value4;
+    ASSERT_TRUE(kv->Put("123456789", "D") == OK);
+    ASSERT_TRUE(kv->Count() == 4);
+    ASSERT_TRUE(kv->Get("123456789", &value4) == OK && value4 == "D");
+
+    string value5;
+    ASSERT_TRUE(kv->Put("123456789ABCDEFGHI", "E") == OK);
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Get("123456789ABCDEFGHI", &value5) == OK && value5 == "E");
+}
+
+TEST_F(StdMapTest, PutValuesOfDifferentSizesTest) {
+    string value;
+    ASSERT_TRUE(kv->Put("A", "123456789ABCDE") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("A", &value) == OK && value == "123456789ABCDE");
+
+    string value2;
+    ASSERT_TRUE(kv->Put("B", "123456789ABCDEF") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Get("B", &value2) == OK && value2 == "123456789ABCDEF");
+
+    string value3;
+    ASSERT_TRUE(kv->Put("C", "12345678ABCDEFG") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    ASSERT_TRUE(kv->Get("C", &value3) == OK && value3 == "12345678ABCDEFG");
+
+    string value4;
+    ASSERT_TRUE(kv->Put("D", "123456789") == OK);
+    ASSERT_TRUE(kv->Count() == 4);
+    ASSERT_TRUE(kv->Get("D", &value4) == OK && value4 == "123456789");
+
+    string value5;
+    ASSERT_TRUE(kv->Put("E", "123456789ABCDEFGHI") == OK);
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Get("E", &value5) == OK && value5 == "123456789ABCDEFGHI");
+}
+
+TEST_F(StdMapTest, PutValuesOfMaximumSizeTest) {
+    // todo finish this when max is decided (#61)
+}
+
+TEST_F(StdMapTest, RemoveAllTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+}
+
+TEST_F(StdMapTest, RemoveAndInsertTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("tmpkey1"));
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == OK && value == "tmpvalue1");
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey1"));
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+}
+
+TEST_F(StdMapTest, RemoveExistingTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("tmpkey2", "tmpvalue2") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey1") == NOT_FOUND); // ok to remove twice
+    ASSERT_EQ(kv->Count(), 1);
+    ASSERT_TRUE(!kv->Exists("tmpkey1"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Exists("tmpkey2"));
+    ASSERT_TRUE(kv->Get("tmpkey2", &value) == OK && value == "tmpvalue2");
+}
+
+TEST_F(StdMapTest, RemoveHeadlessTest) {
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+}
+
+TEST_F(StdMapTest, RemoveNonexistentTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+    ASSERT_TRUE(kv->Exists("key1"));
+}

--- a/tests/engines/tbb_hash_map_test.cc
+++ b/tests/engines/tbb_hash_map_test.cc
@@ -1,0 +1,326 @@
+/*
+ * Copyright 2017-2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "../../src/engines/tbb_hash_map.h"
+#include "../../src/pmemkv.h"
+
+using namespace pmemkv::tbb_hash_map;
+
+std::vector<std::unique_ptr<TbbHashMap>> tbb_garbage_collector;
+
+class TbbHashMapTest : public testing::Test {
+public:
+    TbbHashMap* kv;
+    TbbHashMapTest() {
+        kv = new TbbHashMap("/dev/shm", 1024 * 1024 * 1024);
+    }
+
+    ~TbbHashMapTest() {
+        delete kv;
+    }
+};
+
+TEST_F(TbbHashMapTest, SimpleTest) {
+    string value;
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Get("key1", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "value1");
+}
+
+TEST_F(TbbHashMapTest, BinaryKeyTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("a"));
+    ASSERT_TRUE(kv->Put("a", "should_not_change") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("a"));
+    string key1 = string("a\0b", 3);
+    ASSERT_TRUE(!kv->Exists(key1));
+    ASSERT_TRUE(kv->Put(key1, "stuff") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Exists("a"));
+    ASSERT_TRUE(kv->Exists(key1));
+    string value;
+    ASSERT_TRUE(kv->Get(key1, &value) == OK);
+    ASSERT_EQ(value, "stuff");
+    string value2;
+    ASSERT_TRUE(kv->Get("a", &value2) == OK);
+    ASSERT_EQ(value2, "should_not_change");
+    ASSERT_TRUE(kv->Remove(key1) == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("a"));
+    ASSERT_TRUE(!kv->Exists(key1));
+    string value3;
+    ASSERT_TRUE(kv->Get(key1, &value3) == NOT_FOUND);
+    ASSERT_TRUE(kv->Get("a", &value3) == OK && value3 == "should_not_change");
+}
+
+TEST_F(TbbHashMapTest, BinaryValueTest) {
+    string value("A\0B\0\0C", 6);
+    ASSERT_TRUE(kv->Put("key1", value) == OK);
+    string value_out;
+    ASSERT_TRUE(kv->Get("key1", &value_out) == OK && memcmp(&value[0], &value_out[0], 6) == 0);
+}
+
+TEST_F(TbbHashMapTest, EmptyKeyTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("", "empty") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put(" ", "single-space") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Put("\t\t", "two-tab") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    string value1;
+    string value2;
+    string value3;
+    ASSERT_TRUE(kv->Exists(""));
+    ASSERT_TRUE(kv->Get("", &value1) == OK && value1 == "empty");
+    ASSERT_TRUE(kv->Exists(" "));
+    ASSERT_TRUE(kv->Get(" ", &value2) == OK && value2 == "single-space");
+    ASSERT_TRUE(kv->Exists("\t\t"));
+    ASSERT_TRUE(kv->Get("\t\t", &value3) == OK && value3 == "two-tab");
+}
+
+TEST_F(TbbHashMapTest, EmptyValueTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("empty", "") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("single-space", " ") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Put("two-tab", "\t\t") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    string value1;
+    string value2;
+    string value3;
+    ASSERT_TRUE(kv->Get("empty", &value1) == OK && value1 == "");
+    ASSERT_TRUE(kv->Get("single-space", &value2) == OK && value2 == " ");
+    ASSERT_TRUE(kv->Get("two-tab", &value3) == OK && value3 == "\t\t");
+}
+
+TEST_F(TbbHashMapTest, GetAppendToExternalValueTest) {
+    ASSERT_TRUE(kv->Put("key1", "cool") == OK);
+    string value = "super";
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "supercool");
+}
+
+TEST_F(TbbHashMapTest, GetHeadlessTest) {
+    ASSERT_TRUE(!kv->Exists("waldo"));
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(TbbHashMapTest, GetMultipleTest) {
+    ASSERT_TRUE(kv->Put("abc", "A1") == OK);
+    ASSERT_TRUE(kv->Put("def", "B2") == OK);
+    ASSERT_TRUE(kv->Put("hij", "C3") == OK);
+    ASSERT_TRUE(kv->Put("jkl", "D4") == OK);
+    ASSERT_TRUE(kv->Put("mno", "E5") == OK);
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Exists("abc"));
+    string value1;
+    ASSERT_TRUE(kv->Get("abc", &value1) == OK && value1 == "A1");
+    ASSERT_TRUE(kv->Exists("def"));
+    string value2;
+    ASSERT_TRUE(kv->Get("def", &value2) == OK && value2 == "B2");
+    ASSERT_TRUE(kv->Exists("hij"));
+    string value3;
+    ASSERT_TRUE(kv->Get("hij", &value3) == OK && value3 == "C3");
+    ASSERT_TRUE(kv->Exists("jkl"));
+    string value4;
+    ASSERT_TRUE(kv->Get("jkl", &value4) == OK && value4 == "D4");
+    ASSERT_TRUE(kv->Exists("mno"));
+    string value5;
+    ASSERT_TRUE(kv->Get("mno", &value5) == OK && value5 == "E5");
+}
+
+TEST_F(TbbHashMapTest, GetMultiple2Test) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Put("key2", "value2") == OK);
+    ASSERT_TRUE(kv->Put("key3", "value3") == OK);
+    ASSERT_TRUE(kv->Remove("key2") == OK);
+    ASSERT_TRUE(kv->Put("key3", "VALUE3") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    string value1;
+    ASSERT_TRUE(kv->Get("key1", &value1) == OK && value1 == "value1");
+    string value2;
+    ASSERT_TRUE(kv->Get("key2", &value2) == NOT_FOUND);
+    string value3;
+    ASSERT_TRUE(kv->Get("key3", &value3) == OK && value3 == "VALUE3");
+}
+
+TEST_F(TbbHashMapTest, GetNonexistentTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(!kv->Exists("waldo"));
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(TbbHashMapTest, PutTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+
+    string value;
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "value1");
+
+    string new_value;
+    ASSERT_TRUE(kv->Put("key1", "VALUE1") == OK);           // same size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value) == OK && new_value == "VALUE1");
+
+    string new_value2;
+    ASSERT_TRUE(kv->Put("key1", "new_value") == OK);        // longer size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value2) == OK && new_value2 == "new_value");
+
+    string new_value3;
+    ASSERT_TRUE(kv->Put("key1", "?") == OK);                // shorter size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value3) == OK && new_value3 == "?");
+}
+
+TEST_F(TbbHashMapTest, PutKeysOfDifferentSizesTest) {
+    string value;
+    ASSERT_TRUE(kv->Put("123456789ABCDE", "A") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("123456789ABCDE", &value) == OK && value == "A");
+
+    string value2;
+    ASSERT_TRUE(kv->Put("123456789ABCDEF", "B") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Get("123456789ABCDEF", &value2) == OK && value2 == "B");
+
+    string value3;
+    ASSERT_TRUE(kv->Put("12345678ABCDEFG", "C") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    ASSERT_TRUE(kv->Get("12345678ABCDEFG", &value3) == OK && value3 == "C");
+
+    string value4;
+    ASSERT_TRUE(kv->Put("123456789", "D") == OK);
+    ASSERT_TRUE(kv->Count() == 4);
+    ASSERT_TRUE(kv->Get("123456789", &value4) == OK && value4 == "D");
+
+    string value5;
+    ASSERT_TRUE(kv->Put("123456789ABCDEFGHI", "E") == OK);
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Get("123456789ABCDEFGHI", &value5) == OK && value5 == "E");
+}
+
+TEST_F(TbbHashMapTest, PutValuesOfDifferentSizesTest) {
+    string value;
+    ASSERT_TRUE(kv->Put("A", "123456789ABCDE") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("A", &value) == OK && value == "123456789ABCDE");
+
+    string value2;
+    ASSERT_TRUE(kv->Put("B", "123456789ABCDEF") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Get("B", &value2) == OK && value2 == "123456789ABCDEF");
+
+    string value3;
+    ASSERT_TRUE(kv->Put("C", "12345678ABCDEFG") == OK);
+    ASSERT_TRUE(kv->Count() == 3);
+    ASSERT_TRUE(kv->Get("C", &value3) == OK && value3 == "12345678ABCDEFG");
+
+    string value4;
+    ASSERT_TRUE(kv->Put("D", "123456789") == OK);
+    ASSERT_TRUE(kv->Count() == 4);
+    ASSERT_TRUE(kv->Get("D", &value4) == OK && value4 == "123456789");
+
+    string value5;
+    ASSERT_TRUE(kv->Put("E", "123456789ABCDEFGHI") == OK);
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Get("E", &value5) == OK && value5 == "123456789ABCDEFGHI");
+}
+
+TEST_F(TbbHashMapTest, PutValuesOfMaximumSizeTest) {
+    // todo finish this when max is decided (#61)
+}
+
+TEST_F(TbbHashMapTest, RemoveAllTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+}
+
+TEST_F(TbbHashMapTest, RemoveAndInsertTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("tmpkey1"));
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == OK && value == "tmpvalue1");
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey1"));
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+}
+
+TEST_F(TbbHashMapTest, RemoveExistingTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("tmpkey2", "tmpvalue2") == OK);
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey1") == NOT_FOUND); // ok to remove twice
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(!kv->Exists("tmpkey1"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Exists("tmpkey2"));
+    ASSERT_TRUE(kv->Get("tmpkey2", &value) == OK && value == "tmpvalue2");
+}
+
+TEST_F(TbbHashMapTest, RemoveHeadlessTest) {
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+}
+
+TEST_F(TbbHashMapTest, RemoveNonexistentTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK);
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+    ASSERT_TRUE(kv->Exists("key1"));
+}


### PR DESCRIPTION
Adding two new engines for volatile usage of persistent memory.
This two engines built on top of new C++ pmem allocator. This allocator
currently is on review for memkind library. When The C++ pmem allocator
will be accepted to be part of memkind we can enable these two new
engines.

Right now we are commiting only sources, without changes in the build
system.