### PR TITLE
Enable std::map engine with memkind allocator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ cmake_minimum_required(VERSION 3.5)
 project(pmemkv)
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 set(SOURCE_FILES src/pmemkv.cc src/pmemkv.h
     src/engines/blackhole.h src/engines/blackhole.cc
     src/engines/kvtree2.h src/engines/kvtree2.cc
@@ -39,12 +40,28 @@ set(SOURCE_FILES src/pmemkv.cc src/pmemkv.h
     src/engines/btree.h src/engines/btree.cc
     src/engines/btree/persistent_b_tree.h src/engines/btree/pstring.h
 )
+set(TEST_FILES tests/pmemkv_test.cc tests/mock_tx_alloc.cc
+	tests/engines/blackhole_test.cc
+	tests/engines/btree_test.cc
+	tests/engines/kvtree_test.cc
+)
 set(3RDPARTY ${PROJECT_SOURCE_DIR}/3rdparty)
 set(GTEST_VERSION 1.7.0)
 
 find_package(PkgConfig QUIET)
 include(ExternalProject)
 include(FindThreads)
+include(FindMemkind)
+
+if(MEMKIND_FOUND)
+	add_definitions(-D__PMEMKV_WITH_MEMKIND)
+	set(SOURCE_FILES ${SOURCE_FILES}
+		src/engines/vmap.h src/engines/vmap.cc
+	)
+	set(TEST_FILES ${TEST_FILES}
+		tests/engines/vmap_test.cc
+	)
+endif()
 
 set(GTEST_URL ${CMAKE_SOURCE_DIR}/googletest-${GTEST_VERSION}.zip)
 if(EXISTS ${GTEST_URL})
@@ -76,12 +93,10 @@ endif()
 include_directories(${PMEMOBJ++_INCLUDE_DIRS})
 link_directories(${PMEMOBJ++_LIBRARY_DIRS})
 
-add_library(pmemkv SHARED ${SOURCE_FILES})
-target_link_libraries(pmemkv ${PMEMOBJ++_LIBRARIES})
+include_directories(${MEMKIND_INCLUDE_DIR})
 
-add_executable(pmemkv_test tests/pmemkv_test.cc tests/mock_tx_alloc.cc
-               tests/engines/blackhole_test.cc
-               tests/engines/btree_test.cc
-               tests/engines/kvtree_test.cc
-)
+add_library(pmemkv SHARED ${SOURCE_FILES})
+target_link_libraries(pmemkv ${PMEMOBJ++_LIBRARIES} ${MEMKIND_LIBRARY})
+
+add_executable(pmemkv_test ${TEST_FILES})
 target_link_libraries(pmemkv_test pmemkv libgtest ${CMAKE_DL_LIBS})

--- a/cmake/FindMemkind.cmake
+++ b/cmake/FindMemkind.cmake
@@ -1,0 +1,17 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(MEMKIND_INCLUDE_DIR pmem_allocator.h)
+find_library(MEMKIND_LIBRARY NAMES memkind libmemkind)
+
+find_package_handle_standard_args(MEMKIND
+	DEFAULT_MSG
+	MEMKIND_INCLUDE_DIR
+	MEMKIND_LIBRARY
+	)
+
+mark_as_advanced(MEMKIND_LIBRARY MEMKIND_INCLUDE_DIR)
+
+if(MEMKIND_FOUND)
+	set(MEMKIND_LIBRARIES ${MEMKIND_LIBRARY})
+	set(MEMKIND_INCLUDE_DIRS ${MEMKIND_INCLUDE_DIR})
+endif()

--- a/src/engines/vmap.cc
+++ b/src/engines/vmap.cc
@@ -52,21 +52,19 @@ VMap::~VMap() {
 void VMap::All(void* context, KVAllCallback* callback) {
     LOG("All");
     for (auto& iterator : pmem_kv_container) {
-        (*callback)(context, (int32_t) iterator.first.size(), (int32_t) iterator.second.size());
+        (*callback)(context, (int32_t) iterator.first.size(), iterator.first.c_str());
     }
 }
 
 int64_t VMap::Count() {
-    int64_t result = 0;
-    for (auto& iterator : pmem_kv_container) result++;
-    return result;
+    return pmem_kv_container.size();
 }
 
 void VMap::Each(void* context, KVEachCallback* callback) {
     LOG("Each");
     for (auto& iterator : pmem_kv_container) {
-        (*callback)(context, (int32_t) iterator.first.size(), (int32_t) iterator.second.size(),
-                    iterator.first.c_str(), iterator.second.c_str());
+        (*callback)(context, (int32_t) iterator.first.size(), iterator.first.c_str(),
+                (int32_t) iterator.second.size(), iterator.second.c_str());
     }
 }
 
@@ -88,7 +86,8 @@ void VMap::Get(void* context, const string& key, KVGetCallback* callback) {
 
 KVStatus VMap::Put(const string& key, const string& value) {
     LOG("Put key=" << key << ", value.size=" << to_string(value.size()));
-    pmem_kv_container[pmem_string(key.c_str(), key.size(), ch_allocator)] = pmem_string(value.c_str(), value.size(), ch_allocator);
+    pmem_kv_container[pmem_string(key.c_str(), key.size(), ch_allocator)] = 
+        pmem_string(value.c_str(), value.size(), ch_allocator);
     return OK;
 }
 

--- a/src/pmemkv.cc
+++ b/src/pmemkv.cc
@@ -34,6 +34,9 @@
 #include "engines/kvtree2.h"
 #include "engines/kvtree3.h"
 #include "engines/btree.h"
+#ifdef __PMEMKV_WITH_MEMKIND
+#include "engines/vmap.h"
+#endif
 
 namespace pmemkv {
 
@@ -47,6 +50,10 @@ KVEngine* KVEngine::Open(const string& engine, const string& path, const size_t 
             return new kvtree3::KVTree(path, size);
         } else if (engine == btree::ENGINE) {
             return new btree::BTree(path, size);
+#ifdef __PMEMKV_WITH_MEMKIND
+        } else if(engine == vmap::ENGINE) {
+            return new vmap::VMap(path, size);
+#endif
         } else {
             return nullptr;
         }
@@ -65,6 +72,10 @@ void KVEngine::Close(KVEngine* kv) {
         delete (kvtree3::KVTree*) kv;
     } else if (engine == btree::ENGINE) {
         delete (btree::BTree*) kv;
+#ifdef __PMEMKV_WITH_MEMKIND
+    } else if(engine == vmap::ENGINE) {
+        delete (vmap::VMap*) kv;
+#endif
     }
 }
 

--- a/tests/engines/vmap_test.cc
+++ b/tests/engines/vmap_test.cc
@@ -1,0 +1,523 @@
+/*
+ * Copyright 2017-2018, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "gtest/gtest.h"
+#include "../../src/engines/vmap.h"
+
+using namespace pmemkv::vmap;
+
+const string PATH = "/dev/shm";
+const size_t SIZE = 1024ull * 1024ull * 512ull;
+const size_t LARGE_SIZE = 1024ull * 1024ull * 1024ull * 2ull;
+
+template<size_t POOL_SIZE>
+class VMapBaseTest : public testing::Test {
+public:
+    VMap* kv;
+
+    VMapBaseTest() {
+        Open();
+    }
+
+    ~VMapBaseTest() {
+        delete kv;
+    }
+
+    void Reopen() {
+        delete kv;
+        Open();
+    }
+
+protected:
+    void Open() {
+        kv = new VMap(PATH, POOL_SIZE);
+    }
+};
+
+using VMapTest = VMapBaseTest<SIZE>;
+using VMapLargeTest = VMapBaseTest<LARGE_SIZE>;
+
+
+TEST_F(VMapTest, SimpleTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("key1"));
+    string value;
+    ASSERT_TRUE(kv->Get("key1", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("key1"));
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "value1");
+}
+
+TEST_F(VMapTest, BinaryKeyTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("a"));
+    ASSERT_TRUE(kv->Put("a", "should_not_change") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("a"));
+    string key1 = string("a\0b", 3);
+    ASSERT_TRUE(!kv->Exists(key1));
+    ASSERT_TRUE(kv->Put(key1, "stuff") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Exists("a"));
+    ASSERT_TRUE(kv->Exists(key1));
+    string value;
+    ASSERT_TRUE(kv->Get(key1, &value) == OK);
+    ASSERT_EQ(value, "stuff");
+    string value2;
+    ASSERT_TRUE(kv->Get("a", &value2) == OK);
+    ASSERT_EQ(value2, "should_not_change");
+    ASSERT_TRUE(kv->Remove(key1) == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("a"));
+    ASSERT_TRUE(!kv->Exists(key1));
+    string value3;
+    ASSERT_TRUE(kv->Get(key1, &value3) == NOT_FOUND);
+    ASSERT_TRUE(kv->Get("a", &value3) == OK && value3 == "should_not_change");
+}
+
+TEST_F(VMapTest, BinaryValueTest) {
+    string value("A\0B\0\0C", 6);
+    ASSERT_TRUE(kv->Put("key1", value) == OK) << pmemobj_errormsg();
+    string value_out;
+    ASSERT_TRUE(kv->Get("key1", &value_out) == OK && (value_out.length() == 6) && (value_out == value));
+}
+
+TEST_F(VMapTest, EmptyKeyTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("", "empty") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put(" ", "single-space") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Put("\t\t", "two-tab") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 3);
+    string value1;
+    string value2;
+    string value3;
+    ASSERT_TRUE(kv->Exists(""));
+    ASSERT_TRUE(kv->Get("", &value1) == OK && value1 == "empty");
+    ASSERT_TRUE(kv->Exists(" "));
+    ASSERT_TRUE(kv->Get(" ", &value2) == OK && value2 == "single-space");
+    ASSERT_TRUE(kv->Exists("\t\t"));
+    ASSERT_TRUE(kv->Get("\t\t", &value3) == OK && value3 == "two-tab");
+}
+
+TEST_F(VMapTest, EmptyValueTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("empty", "") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("single-space", " ") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Put("two-tab", "\t\t") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 3);
+    string value1;
+    string value2;
+    string value3;
+    ASSERT_TRUE(kv->Get("empty", &value1) == OK && value1 == "");
+    ASSERT_TRUE(kv->Get("single-space", &value2) == OK && value2 == " ");
+    ASSERT_TRUE(kv->Get("two-tab", &value3) == OK && value3 == "\t\t");
+}
+
+TEST_F(VMapTest, GetAppendToExternalValueTest) {
+    ASSERT_TRUE(kv->Put("key1", "cool") == OK) << pmemobj_errormsg();
+    string value = "super";
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "supercool");
+}
+
+TEST_F(VMapTest, GetHeadlessTest) {
+    ASSERT_TRUE(!kv->Exists("waldo"));
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, GetMultipleTest) {
+    ASSERT_TRUE(kv->Put("abc", "A1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("def", "B2") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("hij", "C3") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("jkl", "D4") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("mno", "E5") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Exists("abc"));
+    string value1;
+    ASSERT_TRUE(kv->Get("abc", &value1) == OK && value1 == "A1");
+    ASSERT_TRUE(kv->Exists("def"));
+    string value2;
+    ASSERT_TRUE(kv->Get("def", &value2) == OK && value2 == "B2");
+    ASSERT_TRUE(kv->Exists("hij"));
+    string value3;
+    ASSERT_TRUE(kv->Get("hij", &value3) == OK && value3 == "C3");
+    ASSERT_TRUE(kv->Exists("jkl"));
+    string value4;
+    ASSERT_TRUE(kv->Get("jkl", &value4) == OK && value4 == "D4");
+    ASSERT_TRUE(kv->Exists("mno"));
+    string value5;
+    ASSERT_TRUE(kv->Get("mno", &value5) == OK && value5 == "E5");
+}
+
+TEST_F(VMapTest, GetMultiple2Test) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("key2", "value2") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("key3", "value3") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Remove("key2") == OK);
+    ASSERT_TRUE(kv->Put("key3", "VALUE3") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+    string value1;
+    ASSERT_TRUE(kv->Get("key1", &value1) == OK && value1 == "value1");
+    string value2;
+    ASSERT_TRUE(kv->Get("key2", &value2) == NOT_FOUND);
+    string value3;
+    ASSERT_TRUE(kv->Get("key3", &value3) == OK && value3 == "VALUE3");
+}
+
+TEST_F(VMapTest, GetNonexistentTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(!kv->Exists("waldo"));
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, PutTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+
+    string value;
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "value1");
+
+    string new_value;
+    ASSERT_TRUE(kv->Put("key1", "VALUE1") == OK) << pmemobj_errormsg();           // same size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value) == OK && new_value == "VALUE1");
+
+    string new_value2;
+    ASSERT_TRUE(kv->Put("key1", "new_value") == OK) << pmemobj_errormsg();        // longer size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value2) == OK && new_value2 == "new_value");
+
+    string new_value3;
+    ASSERT_TRUE(kv->Put("key1", "?") == OK) << pmemobj_errormsg();                // shorter size
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("key1", &new_value3) == OK && new_value3 == "?");
+}
+
+TEST_F(VMapTest, PutKeysOfDifferentSizesTest) {
+    string value;
+    ASSERT_TRUE(kv->Put("123456789ABCDE", "A") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("123456789ABCDE", &value) == OK && value == "A");
+
+    string value2;
+    ASSERT_TRUE(kv->Put("123456789ABCDEF", "B") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Get("123456789ABCDEF", &value2) == OK && value2 == "B");
+
+    string value3;
+    ASSERT_TRUE(kv->Put("12345678ABCDEFG", "C") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 3);
+    ASSERT_TRUE(kv->Get("12345678ABCDEFG", &value3) == OK && value3 == "C");
+
+    string value4;
+    ASSERT_TRUE(kv->Put("123456789", "D") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 4);
+    ASSERT_TRUE(kv->Get("123456789", &value4) == OK && value4 == "D");
+
+    string value5;
+    ASSERT_TRUE(kv->Put("123456789ABCDEFGHI", "E") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Get("123456789ABCDEFGHI", &value5) == OK && value5 == "E");
+}
+
+TEST_F(VMapTest, PutValuesOfDifferentSizesTest) {
+    string value;
+    ASSERT_TRUE(kv->Put("A", "123456789ABCDE") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Get("A", &value) == OK && value == "123456789ABCDE");
+
+    string value2;
+    ASSERT_TRUE(kv->Put("B", "123456789ABCDEF") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Get("B", &value2) == OK && value2 == "123456789ABCDEF");
+
+    string value3;
+    ASSERT_TRUE(kv->Put("C", "12345678ABCDEFG") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 3);
+    ASSERT_TRUE(kv->Get("C", &value3) == OK && value3 == "12345678ABCDEFG");
+
+    string value4;
+    ASSERT_TRUE(kv->Put("D", "123456789") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 4);
+    ASSERT_TRUE(kv->Get("D", &value4) == OK && value4 == "123456789");
+
+    string value5;
+    ASSERT_TRUE(kv->Put("E", "123456789ABCDEFGHI") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 5);
+    ASSERT_TRUE(kv->Get("E", &value5) == OK && value5 == "123456789ABCDEFGHI");
+}
+
+TEST_F(VMapTest, RemoveAllTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, RemoveAndInsertTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Exists("tmpkey1"));
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == OK && value == "tmpvalue1");
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(!kv->Exists("tmpkey1"));
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, RemoveExistingTest) {
+    ASSERT_TRUE(kv->Count() == 0);
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("tmpkey2", "tmpvalue2") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Remove("tmpkey1") == NOT_FOUND);
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(!kv->Exists("tmpkey1"));
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Exists("tmpkey2"));
+    ASSERT_TRUE(kv->Get("tmpkey2", &value) == OK && value == "tmpvalue2");
+}
+
+TEST_F(VMapTest, RemoveHeadlessTest) {
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+}
+
+TEST_F(VMapTest, RemoveNonexistentTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+    ASSERT_TRUE(kv->Exists("key1"));
+}
+
+TEST_F(VMapTest, UsesAllTest) {
+    ASSERT_TRUE(kv->Put("2", "1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("记!", "RR") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+
+    string result;
+    kv->All(&result, [](void* context, int kb, const char* k) {
+        const auto c = ((string*) context);
+        c->append("<");
+        c->append(string(k, kb));
+        c->append(">,");
+    });
+    ASSERT_TRUE(result == "<2>,<记!>,");
+}
+
+TEST_F(VMapTest, UsesEachTest) {
+    ASSERT_TRUE(kv->Put("1", "2") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 1);
+    ASSERT_TRUE(kv->Put("RR", "记!") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Count() == 2);
+
+    string result;
+    kv->Each(&result, [](void* context, int kb, const char* k, int vb, const char* v) {
+            const auto c = ((string*) context);
+            c->append("<");
+            c->append(string(k, kb));
+            c->append(">,<");
+            c->append(string(v, vb));
+            c->append(">|");
+    });
+    ASSERT_TRUE(result == "<1>,<2>|<RR>,<记!>|");
+}
+
+// =============================================================================================
+// TEST RECOVERY OF SINGLE-LEAF TREE
+// =============================================================================================
+
+TEST_F(VMapTest, GetHeadlessAfterRecoveryTest) {
+    Reopen();
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, GetMultipleAfterRecoveryTest) {
+    ASSERT_TRUE(kv->Put("abc", "A1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("def", "B2") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("hij", "C3") == OK) << pmemobj_errormsg();
+    Reopen();
+    ASSERT_TRUE(kv->Put("jkl", "D4") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("mno", "E5") == OK) << pmemobj_errormsg();
+    string value1;
+    ASSERT_TRUE(kv->Get("abc", &value1) == NOT_FOUND);
+    string value2;
+    ASSERT_TRUE(kv->Get("def", &value2) == NOT_FOUND);
+    string value3;
+    ASSERT_TRUE(kv->Get("hij", &value3) == NOT_FOUND);
+    string value4;
+    ASSERT_TRUE(kv->Get("jkl", &value4) == OK && value4 == "D4");
+    string value5;
+    ASSERT_TRUE(kv->Get("mno", &value5) == OK && value5 == "E5");
+}
+
+TEST_F(VMapTest, GetMultiple2AfterRecoveryTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("key2", "value2") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("key3", "value3") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Remove("key2") == OK);
+    ASSERT_TRUE(kv->Put("key3", "VALUE3") == OK) << pmemobj_errormsg();
+    Reopen();
+    string value1;
+    ASSERT_TRUE(kv->Get("key1", &value1) == NOT_FOUND);
+    string value2;
+    ASSERT_TRUE(kv->Get("key2", &value2) == NOT_FOUND);
+    string value3;
+    ASSERT_TRUE(kv->Get("key3", &value3) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, GetNonexistentAfterRecoveryTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    Reopen();
+    string value;
+    ASSERT_TRUE(kv->Get("waldo", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, PutAfterRecoveryTest) {
+    string value;
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Get("key1", &value) == OK && value == "value1");
+
+    string new_value;
+    ASSERT_TRUE(kv->Put("key1", "VALUE1") == OK) << pmemobj_errormsg();           // same size
+    ASSERT_TRUE(kv->Get("key1", &new_value) == OK && new_value == "VALUE1");
+    Reopen();
+
+    string new_value2;
+    ASSERT_TRUE(kv->Put("key1", "new_value") == OK) << pmemobj_errormsg();        // longer size
+    ASSERT_TRUE(kv->Get("key1", &new_value2) == OK && new_value2 == "new_value");
+
+    string new_value3;
+    ASSERT_TRUE(kv->Put("key1", "?") == OK) << pmemobj_errormsg();                // shorter size
+    ASSERT_TRUE(kv->Get("key1", &new_value3) == OK && new_value3 == "?");
+}
+
+TEST_F(VMapTest, RemoveAllAfterRecoveryTest) {
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK) << pmemobj_errormsg();
+    Reopen();
+    ASSERT_TRUE(kv->Remove("tmpkey") == NOT_FOUND);
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, RemoveAndInsertAfterRecoveryTest) {
+    ASSERT_TRUE(kv->Put("tmpkey", "tmpvalue1") == OK) << pmemobj_errormsg();
+    Reopen();
+    ASSERT_TRUE(kv->Remove("tmpkey") == NOT_FOUND);
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == OK && value == "tmpvalue1");
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, RemoveExistingAfterRecoveryTest) {
+    ASSERT_TRUE(kv->Put("tmpkey1", "tmpvalue1") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Put("tmpkey2", "tmpvalue2") == OK) << pmemobj_errormsg();
+    ASSERT_TRUE(kv->Remove("tmpkey1") == OK);
+    Reopen();
+    ASSERT_TRUE(kv->Remove("tmpkey1") == NOT_FOUND); // ok to remove twice
+    string value;
+    ASSERT_TRUE(kv->Get("tmpkey1", &value) == NOT_FOUND);
+    ASSERT_TRUE(kv->Get("tmpkey2", &value) == NOT_FOUND);
+}
+
+TEST_F(VMapTest, RemoveHeadlessAfterRecoveryTest) {
+    Reopen();
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+}
+
+TEST_F(VMapTest, RemoveNonexistentAfterRecoveryTest) {
+    ASSERT_TRUE(kv->Put("key1", "value1") == OK) << pmemobj_errormsg();
+    Reopen();
+    ASSERT_TRUE(kv->Remove("nada") == NOT_FOUND);
+}
+
+// =============================================================================================
+// TEST LARGE TREE
+// =============================================================================================
+
+const int LARGE_LIMIT = 4000000;
+
+TEST_F(VMapLargeTest, LargeAscendingTest) {
+    for (int i = 1; i <= LARGE_LIMIT; i++) {
+        string istr = to_string(i);
+        ASSERT_TRUE(kv->Put(istr, (istr + "!")) == OK) << pmemobj_errormsg();
+        string value;
+        ASSERT_TRUE(kv->Get(istr, &value) == OK && value == (istr + "!"));
+    }
+    for (int i = 1; i <= LARGE_LIMIT; i++) {
+        string istr = to_string(i);
+        string value;
+        ASSERT_TRUE(kv->Get(istr, &value) == OK && value == (istr + "!"));
+    }
+    ASSERT_TRUE(kv->Count() == LARGE_LIMIT);
+}
+
+TEST_F(VMapLargeTest, LargeDescendingTest) {
+    for (int i = LARGE_LIMIT; i >= 1; i--) {
+        string istr = to_string(i);
+        ASSERT_TRUE(kv->Put(istr, ("ABC" + istr)) == OK) << pmemobj_errormsg();
+        string value;
+        ASSERT_TRUE(kv->Get(istr, &value) == OK && value == ("ABC" + istr));
+    }
+    for (int i = LARGE_LIMIT; i >= 1; i--) {
+        string istr = to_string(i);
+        string value;
+        ASSERT_TRUE(kv->Get(istr, &value) == OK && value == ("ABC" + istr));
+    }
+    ASSERT_TRUE(kv->Count() == LARGE_LIMIT);
+}


### PR DESCRIPTION
Memkind introduced PMEM C++ allocator for volatile usage of AppDirect
mode. This allocator enables STL-like data structure to allocate memory
on persistent memory exposed through memory-mapped files.