### PR TITLE
Add Dockerfiles and build scripts for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+travis.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # pmemkv
+
+[![Build Status](https://travis-ci.org/pmem/pmemkv.svg?branch=master)](https://travis-ci.org/pmem/pmemkv)
+
 Key/Value Datastore for Persistent Memory
 
 *This is experimental pre-release software and should not be used in

--- a/travis.yml
+++ b/travis.yml
@@ -1,0 +1,29 @@
+dist: trusty
+
+sudo: required
+
+language: cpp
+
+services:
+  - docker
+
+env:
+  matrix:
+    - TYPE=normal OS=fedora OS_VER=28 PUSH_IMAGE=1
+
+before_install:
+  - echo $TRAVIS_COMMIT_RANGE
+  - export HOST_WORKDIR=`pwd`
+  - export GITHUB_REPO=pmem/pmemkv
+  - export DOCKERHUB_REPO=pmem/pmemkv
+  - cd utils/docker
+  - ./pull-or-rebuild-image.sh
+  - if [[ -f push_image_to_repo_flag ]]; then PUSH_THE_IMAGE=1; fi
+  - if [[ -f skip_build_package_check ]]; then export SKIP_CHECK=1; fi
+  - rm -f push_image_to_repo_flag skip_build_package_check
+
+script:
+  - ./build.sh
+
+after_success:
+  - if [[ $PUSH_THE_IMAGE -eq 1 ]]; then images/push-image.sh $OS-$OS_VER; fi

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# Copyright 2017-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# build.sh - runs a Docker container from a Docker image with environment
+#            prepared for running pmemkv build and tests.
+#
+#
+# Notes:
+# - run this script from its location or set the variable 'HOST_WORKDIR' to
+#   where the root of this project is on the host machine,
+# - set variables 'OS' and 'OS_VER' properly to a system you want to build this
+#   repo on (for proper values take a look on the list of Dockerfiles at the
+#   utils/docker/images directory), eg. OS=ubuntu, OS_VER=16.04.
+#
+
+set -e
+
+if [[ -z "$OS" || -z "$OS_VER" ]]; then
+	echo "ERROR: The variables OS and OS_VER have to be set " \
+		"(eg. OS=fedora, OS_VER=28)."
+	exit 1
+fi
+
+if [[ -z "$HOST_WORKDIR" ]]; then
+	HOST_WORKDIR=$(readlink -f ../..)
+fi
+
+chmod -R a+w $HOST_WORKDIR
+
+imageName=${DOCKERHUB_REPO}:${OS}-${OS_VER}
+containerName=pmemkv-${OS}-${OS_VER}
+
+if [[ "$command" == "" ]]; then
+	command="./run-build.sh";
+fi
+
+if [ -n "$DNS_SERVER" ]; then DNS_SETTING=" --dns=$DNS_SERVER "; fi
+
+
+# Only run doc update on pmem/pmemkv master branch
+if [[ "$TRAVIS_BRANCH" != "master" || "$TRAVIS_PULL_REQUEST" != "false" || "$TRAVIS_REPO_SLUG" != "${GITHUB_REPO}" ]]; then
+	AUTO_DOC_UPDATE=0
+fi
+
+WORKDIR=/pmemkv
+SCRIPTSDIR=$WORKDIR/utils/docker
+
+echo Building ${OS}-${OS_VER}
+
+ci_env=`bash <(curl -s https://codecov.io/env)`
+# Run a container with
+#  - environment variables set (--env)
+#  - host directory containing source mounted (-v)
+#  - working directory set (-w)
+docker run --privileged=true --name=$containerName -ti \
+	$DNS_SETTING \
+	${docker_opts} \
+	$ci_env \
+	--env http_proxy=$http_proxy \
+	--env https_proxy=$https_proxy \
+	--env AUTO_DOC_UPDATE=$AUTO_DOC_UPDATE \
+	--env GITHUB_TOKEN=$GITHUB_TOKEN \
+	--env WORKDIR=$WORKDIR \
+	--env SCRIPTSDIR=$SCRIPTSDIR \
+	--env COVERAGE=$COVERAGE \
+	--env TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG \
+	--env TRAVIS_BRANCH=$TRAVIS_BRANCH \
+	--env TRAVIS_EVENT_TYPE=$TRAVIS_EVENT_TYPE \
+	--env TEST_BUILD=$TEST_BUILD \
+	-v $HOST_WORKDIR:$WORKDIR \
+	-v /etc/localtime:/etc/localtime \
+	-w $SCRIPTSDIR \
+	$imageName $command

--- a/utils/docker/images/Dockerfile.fedora-28
+++ b/utils/docker/images/Dockerfile.fedora-28
@@ -1,0 +1,98 @@
+#
+# Copyright 2016-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# Dockerfile - a 'recipe' for Docker to build an image of fedora-based
+#              environment prepared for running pmemkv build and tests.
+#
+
+# Pull base image
+FROM fedora:28
+MAINTAINER robert.a.dickinson@intel.com
+
+# Install basic tools
+RUN dnf update -y \
+ && dnf install -y \
+	autoconf \
+	automake \
+	clang \
+	cmake \
+	daxctl-devel \
+	doxygen \
+	gcc \
+	gcc-c++ \
+	gdb \
+	git \
+	hub \
+	libtool \
+	make \
+	man \
+	ndctl-devel \
+	numactl-devel \
+	passwd \
+	rapidjson-devel \
+	rpm-build \
+	sudo \
+	unzip \
+	wget \
+	which \
+&& dnf clean all
+
+# Install valgrind
+#COPY install-valgrind.sh install-valgrind.sh
+#RUN ./install-valgrind.sh
+
+# Install pmdk
+COPY install-pmdk.sh install-pmdk.sh
+RUN ./install-pmdk.sh rpm
+
+# Install pmdk c++ bindings
+COPY install-libpmemobj-cpp.sh install-libpmemobj-cpp.sh
+RUN ./install-libpmemobj-cpp.sh RPM
+
+# Install memkind
+COPY install-memkind.sh install-memkind.sh
+RUN ./install-memkind.sh
+
+# Add user
+ENV USER user
+ENV USERPASS pass
+RUN useradd -m $USER
+RUN echo $USERPASS | passwd $USER --stdin
+RUN gpasswd wheel -a $USER
+USER $USER
+
+# Set required environment variables
+ENV OS fedora
+ENV OS_VER 28
+ENV PACKAGE_MANAGER rpm
+ENV NOTTY 1
+

--- a/utils/docker/images/build-image.sh
+++ b/utils/docker/images/build-image.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# build-image.sh <OS-VER> - prepares a Docker image with <OS>-based
+#                           environment for testing pmemkv, according
+#                           to the Dockerfile.<OS-VER> file located
+#                           in the same directory.
+#
+# The script can be run locally.
+#
+
+set -e
+
+function usage {
+	echo "Usage:"
+	echo "    build-image.sh <DOCKERHUB_REPO> <OS-VER>"
+	echo "where <OS-VER>, for example, can be 'fedora-28', provided " \
+		"a Dockerfile named 'Dockerfile.fedora-28' exists in the " \
+		"current directory."
+}
+
+# Check if the first and second argument is nonempty
+if [[ -z "$1" || -z "$2" ]]; then
+	usage
+	exit 1
+fi
+
+# Check if the file Dockerfile.OS-VER exists
+if [[ ! -f "Dockerfile.$2" ]]; then
+	echo "ERROR: wrong argument."
+	usage
+	exit 1
+fi
+
+# Build a Docker image tagged with ${DOCKERHUB_REPO}:OS-VER
+docker build -t $1:$2 \
+	--build-arg http_proxy=$http_proxy \
+	--build-arg https_proxy=$https_proxy \
+	-f Dockerfile.$2 .

--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# install-libpmemobj-cpp.sh <package_type>
+#           - installs PMDK C++ bindings (stable) packages
+#
+
+set -e
+
+git clone https://github.com/pmem/libpmemobj-cpp
+cd libpmemobj-cpp
+# master (right after 1.6) with hash map; March 18th
+git checkout d4206a821d7cfa176fb1b27253295d364d2335da
+
+mkdir build
+cd build
+
+cmake .. -DCPACK_GENERATOR="$1" -DCMAKE_INSTALL_PREFIX=/usr
+make package
+if [ "$1" = "DEB" ]; then
+      sudo dpkg -i libpmemobj++*.deb
+elif [ "$1" = "RPM" ]; then
+      sudo rpm -i libpmemobj++*.rpm
+fi
+
+cd ../..
+rm -r libpmemobj-cpp

--- a/utils/docker/images/install-memkind.sh
+++ b/utils/docker/images/install-memkind.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# install-memkind.sh - installs newest memkind (master)
+#
+
+set -e
+
+git clone https://github.com/memkind/memkind
+cd memkind
+# 1.8.0
+git checkout v1.8.0
+
+./build.sh
+sudo make install
+
+cd ..
+rm -r memkind

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# install-pmdk.sh <package_type> - installs PMDK (stable) packages
+#
+
+set -e
+
+git clone https://github.com/pmem/pmdk
+cd pmdk
+# stable-1.5; January 30th
+git checkout a655a5dfc9c18b3e9a8e634bc2b1974c83e85ddb
+
+make BUILD_PACKAGE_CHECK=n $1
+if [ "$1" = "dpkg" ]; then
+      sudo dpkg -i dpkg/libpmem_*.deb dpkg/libpmem-dev_*.deb
+      sudo dpkg -i dpkg/libpmemobj_*.deb dpkg/libpmemobj-dev_*.deb
+elif [ "$1" = "rpm" ]; then
+      sudo rpm -i rpm/*/pmdk-debuginfo-*.rpm
+      sudo rpm -i rpm/*/libpmem-*.rpm
+      sudo rpm -i rpm/*/libpmemobj-*.rpm
+fi
+
+cd ..
+rm -r pmdk

--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# install-valgrind.sh - installs valgrind for persistent memory
+#
+
+set -e
+
+git clone https://github.com/pmem/valgrind.git
+cd valgrind
+# valgrind v3.14 with pmemcheck
+git checkout 332b3975989d9130486d09493a9571528d66eaf7
+./autogen.sh
+./configure
+make
+sudo make install
+cd ..
+rm -r valgrind

--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# push-image.sh <OS-VER> - pushes the Docker image tagged with OS-VER
+#                          to the Docker Hub.
+#
+# The script utilizes $DOCKERHUB_USER and $DOCKERHUB_PASSWORD variables to log in to
+# Docker Hub. The variables can be set in the Travis project's configuration
+# for automated builds.
+#
+
+set -e
+
+function usage {
+	echo "Usage:"
+	echo "    push-image.sh <OS-VER>"
+	echo "where <OS-VER>, for example, can be 'fedora-28', provided " \
+		"a Docker image tagged with ${DOCKERHUB_REPO}:fedora-28 exists " \
+		"locally."
+}
+
+# Check if the first argument is nonempty
+if [[ -z "$1" ]]; then
+	usage
+	exit 1
+fi
+
+# Check if the image tagged with ${DOCKERHUB_REPO}:OS-VER exists locally
+if [[ ! $(docker images -a | awk -v pattern="^${DOCKERHUB_REPO}:$1\$" \
+	'$1":"$2 ~ pattern') ]]
+then
+	echo "ERROR: wrong argument."
+	usage
+	exit 1
+fi
+
+# Log in to the Docker Hub
+docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PASSWORD"
+
+# Push the image to the repository
+docker push ${DOCKERHUB_REPO}:$1

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# Copyright 2016-2018, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# pull-or-rebuild-image.sh - rebuilds the Docker image used in the
+#                            current Travis build if necessary.
+#
+# The script rebuilds the Docker image if the Dockerfile for the current
+# OS version (Dockerfile.${OS}-${OS_VER}) or any .sh script from the directory
+# with Dockerfiles were modified and committed.
+#
+# If the Travis build is not of the "pull_request" type (i.e. in case of
+# merge after pull_request) and it succeed, the Docker image should be pushed
+# to the Docker Hub repository. An empty file is created to signal that to
+# further scripts.
+#
+# If the Docker image does not have to be rebuilt, it will be pulled from
+# Docker Hub.
+#
+
+set -e
+
+if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
+	&& "$COVERITY" -eq 1 ]]; then
+	echo "INFO: Skip Coverity scan job if build is triggered neither by " \
+		"'cron' nor by a push to 'coverity_scan' branch"
+	exit 0
+fi
+
+if [[ ( "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" )\
+	&& "$COVERITY" -ne 1 ]]; then
+	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
+		" or by a push to 'coverity_scan' branch"
+	exit 0
+fi
+
+if [[ -z "$OS" || -z "$OS_VER" ]]; then
+	echo "ERROR: The variables OS and OS_VER have to be set properly " \
+             "(eg. OS=ubuntu, OS_VER=16.04)."
+	exit 1
+fi
+
+if [[ -z "$HOST_WORKDIR" ]]; then
+	echo "ERROR: The variable HOST_WORKDIR has to contain a path to " \
+		"the root of this project on the host machine"
+	exit 1
+fi
+
+# TRAVIS_COMMIT_RANGE is usually invalid for force pushes - ignore such values
+# when used with non-upstream repository
+if [ -n "$TRAVIS_COMMIT_RANGE" -a $TRAVIS_REPO_SLUG != "${GITHUB_REPO}" ]; then
+	if ! git rev-list $TRAVIS_COMMIT_RANGE; then
+		TRAVIS_COMMIT_RANGE=
+	fi
+fi
+
+# Find all the commits for the current build
+if [[ -n "$TRAVIS_COMMIT_RANGE" ]]; then
+	commits=$(git rev-list $TRAVIS_COMMIT_RANGE)
+else
+	commits=$TRAVIS_COMMIT
+fi
+echo "Commits in the commit range:"
+for commit in $commits; do echo $commit; done
+
+# Get the list of files modified by the commits
+files=$(for commit in $commits; do git diff-tree --no-commit-id --name-only \
+	-r $commit; done | sort -u)
+echo "Files modified within the commit range:"
+for file in $files; do echo $file; done
+
+# Path to directory with Dockerfiles and image building scripts
+images_dir_name=images
+base_dir=utils/docker/$images_dir_name
+
+# Check if committed file modifications require the Docker image to be rebuilt
+for file in $files; do
+	# Check if modified files are relevant to the current build
+	if [[ $file =~ ^($base_dir)\/Dockerfile\.($OS)-($OS_VER)$ ]] \
+		|| [[ $file =~ ^($base_dir)\/.*\.sh$ ]]
+	then
+		# Rebuild Docker image for the current OS version
+		echo "Rebuilding the Docker image for the Dockerfile.$OS-$OS_VER"
+		pushd $images_dir_name
+		./build-image.sh ${DOCKERHUB_REPO} ${OS}-${OS_VER}
+		popd
+
+		# Check if the image has to be pushed to Docker Hub
+		# (i.e. the build is triggered by commits to the ${GITHUB_REPO}
+		# repository's master branch, and the Travis build is not
+		# of the "pull_request" type). In that case, create the empty
+		# file.
+		if [[ $TRAVIS_REPO_SLUG == "${GITHUB_REPO}" \
+			&& $TRAVIS_BRANCH == "master" \
+			&& $TRAVIS_EVENT_TYPE != "pull_request"
+			&& $PUSH_IMAGE == "1" ]]
+		then
+			echo "The image will be pushed to Docker Hub"
+			touch push_image_to_repo_flag
+		else
+			echo "Skip pushing the image to Docker Hub"
+		fi
+
+		if [[ $PUSH_IMAGE == "1" ]]
+		then
+			echo "Skip build package check if image has to be pushed"
+			touch skip_build_package_check
+		fi
+		exit 0
+	fi
+done
+
+# Getting here means rebuilding the Docker image is not required.
+# Pull the image from Docker Hub.
+docker pull ${DOCKERHUB_REPO}:${OS}-${OS_VER}

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# run-build.sh - is called inside a Docker container,
+#                starts pmemkv build with tests.
+#
+
+set -e
+echo $USERPASS | sudo -S mount -oremount,size=4G /dev/shm
+
+cd $WORKDIR
+PREFIX=/usr/local
+
+# make & install
+make
+echo $USERPASS | sudo -S make install
+
+# verify installed package
+LIBFILE=$PREFIX/lib/libpmemkv.so
+HEADERFILE=$PREFIX/include/libpmemkv.h
+
+if [[ -f $LIBFILE && -f $HEADERFILE ]]; then
+	echo "Correctly installed"
+else
+	echo "Installation not successful"
+fi


### PR DESCRIPTION
Adding files for Travis, including docker, building and run scripts. It's based on pmdk & pmdk-convert approach.

Currently build is failing on tests, which need to be investigated. Log on my fork:
https://travis-ci.org/lukaszstolarczuk/pmemkv/builds/487130868

#120

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/161)
<!-- Reviewable:end -->
