### PR TITLE
Workaround to fix CMap engine.

### DIFF
--- a/src/engines/cmap.h
+++ b/src/engines/cmap.h
@@ -33,23 +33,23 @@
 #pragma once
 
 #include "../pmemkv.h"
+#include "../polymorphic_string.h"
 
 #include <libpmemobj++/pool.hpp>
 #include <libpmemobj++/persistent_ptr.hpp>
-#include <libpmemobj++/experimental/string.hpp>
 #include <libpmemobj++/experimental/concurrent_hash_map.hpp>
 
 namespace std {
 template<>
-struct hash<pmem::obj::experimental::string> {
-    template<unsigned u, unsigned long long ull>
+struct hash<pmemkv::polymorphic_string> {
+    template <unsigned u, unsigned long long ull >
     struct select_size_t_constant {
         static const size_t value = (size_t) ((sizeof(size_t) == sizeof(u)) ? u : ull);
     };
 
     static const size_t hash_multiplier = select_size_t_constant<2654435769U, 11400714819323198485ULL>::value;
 
-    size_t operator()(const pmem::obj::experimental::string& str) {
+    size_t operator()(const pmemkv::polymorphic_string &str) {
         size_t h = 0;
         for (size_t i = 0; i < str.size(); ++i) {
             h = static_cast<size_t>(str[i]) ^ (h * hash_multiplier);
@@ -101,7 +101,7 @@ class CMap : public KVEngine {
     using KVEngine::EachBetween;
     using KVEngine::Get;
   private:
-    using string_t = pmem::obj::experimental::string;
+    using string_t = pmemkv::polymorphic_string;
     using map_t = pmem::obj::experimental::concurrent_hash_map<string_t, string_t>;
 
     struct RootData {

--- a/src/polymorphic_string.h
+++ b/src/polymorphic_string.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019, Intel Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided with the
+ *       distribution.
+ *
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived
+ *       from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <string>
+#include <libpmemobj++/experimental/string.hpp>
+#include <libpmemobj++/p.hpp>
+
+namespace pmemkv {
+class polymorphic_string {
+public:
+    using pmem_string = pmem::obj::experimental::string;
+    polymorphic_string() {
+        construct();
+    }
+
+    polymorphic_string(const std::string& s) {
+        construct(s);
+    }
+
+    polymorphic_string(const pmem_string& s) {
+        construct(s.c_str(), s.size());
+    }
+
+    polymorphic_string(const polymorphic_string& s) {
+        construct(s.c_str(), s.size());
+    }
+
+    polymorphic_string& operator=(const std::string& s) {
+        if(is_pmem.get_ro()) {
+            pstr = s;
+        } else {
+            str = s;
+        }
+
+        return *this;
+    }
+
+    polymorphic_string& operator=(const pmem_string& s) {
+        assert(is_pmem.get_ro());
+        pstr = s;
+
+        return *this;
+    }
+
+     polymorphic_string& operator=(const polymorphic_string& s) {
+         if(s.is_pmem.get_ro()) {
+            this->operator=(s.pstr);
+         } else {
+            this->operator=(s.str);
+         }
+
+         return *this;
+     }
+
+    ~polymorphic_string() {
+        if(is_pmem.get_ro()) {
+            pstr.~basic_string();
+        } else {
+            str.~basic_string();
+        }
+    }
+
+    char&  operator[](size_t n) {
+        return is_pmem.get_ro() ? pstr[n] : str[n];
+    }
+
+    const char&  operator[](size_t n) const {
+        return is_pmem.get_ro() ? pstr[n] : str[n];
+    }
+
+    const char* c_str() const {
+        return is_pmem.get_ro() ? pstr.c_str() : str.c_str();
+    }
+
+    size_t size() const {
+        return is_pmem.get_ro() ? pstr.size() : str.size();
+    }
+
+    size_t length() const {
+        return size();
+    }
+
+    bool empty() const {
+        return size() == 0;
+    }
+
+    template <typename... Args>
+    int compare(Args&&... args) const {
+        return is_pmem.get_ro() ? pstr.compare(std::forward<Args>(args)...) : str.compare(std::forward<Args>(args)...);
+    }
+
+    bool operator==(const polymorphic_string& other) const {
+        return compare(0, size(), other.c_str(), other.size()) == 0;
+    }
+
+private:
+    pmem::obj::p<bool> is_pmem;
+    union {
+        std::string str;
+        pmem_string pstr;
+    };
+
+    bool check_pmem() const {
+        return pmemobj_pool_by_ptr(this) != nullptr;
+    }
+
+    template <typename... Args>
+    void construct(Args&&... args) {
+        is_pmem.get_rw() = check_pmem();
+        if(is_pmem.get_ro()) {
+            new(&pstr) pmem_string(std::forward<Args>(args)...);
+        } else {
+            new(&str) std::string(std::forward<Args>(args)...);
+        }
+    }
+}; // class polymorphic_string
+/*
+bool operator==(const polymorphic_string& lhs, const polymorphic_string& rhs) {
+    return lhs.compare(0, lhs.size(), rhs.c_str(), rhs.size()) == 0;
+}*/
+
+/*
+bool operator!=(const polymorphic_string& lhs, const polymorphic_string& rhs) {
+    return lhs.compare(0, lhs.size(), rhs.c_str(), rhs.size()) != 0;
+}
+*/
+
+} // namespace pmemkv

--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -39,8 +39,8 @@ set -e
 
 git clone https://github.com/pmem/libpmemobj-cpp
 cd libpmemobj-cpp
-# master (right after 1.6) with hash map; March 18th
-git checkout d4206a821d7cfa176fb1b27253295d364d2335da
+# master (after 1.6) with hash map and pmem string; March 21th
+git checkout 8d86c76c81167d9e352158ad87f169f554e5d794
 
 mkdir build
 cd build

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -38,8 +38,8 @@ set -e
 
 git clone https://github.com/pmem/pmdk
 cd pmdk
-# stable-1.6; 1.6-rc3
-git checkout d41159e25485f484f8238145e2c5dc280b6c868e
+# stable-1.6
+git checkout 695e6eba28c53a69a0ef7bad3cc0f45c21ef3e00 
 
 make BUILD_PACKAGE_CHECK=n $1
 if [ "$1" = "dpkg" ]; then


### PR DESCRIPTION
Introduce polimorphic string which behaves like std::string if allocated
in system memory and behaves as pmem string if allocated in persistent
memory.

The proper fix would be to introduce polymorphic allocator in PMDK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/173)
<!-- Reviewable:end -->
