### PR TITLE
fix issue #157

### DIFF
--- a/tests/engines-experimental/tree_test.cc
+++ b/tests/engines-experimental/tree_test.cc
@@ -741,7 +741,6 @@ TEST_F(TreeTest, LargeDescendingAfterRecoveryTest) {
 // TEST RUNNING OUT OF SPACE
 // =============================================================================================
 
-/* TEMPORARILY DISABLED -- todo https://github.com/pmem/pmemkv/issues/157
 class TreeFullTest : public testing::Test {
 public:
     Tree *kv;
@@ -895,4 +894,3 @@ TEST_F(TreeFullTest, RepeatedRecoveryTest) {
     for (int i = 1; i <= 100; i++) Restart();
     Validate();
 }
-*/

--- a/tests/mock_tx_alloc.cc
+++ b/tests/mock_tx_alloc.cc
@@ -54,3 +54,17 @@ PMEMoid pmemobj_tx_alloc(size_t size, uint64_t type_num) {
 
     return real(size, type_num);
 }
+
+PMEMoid pmemobj_tx_xalloc(size_t size, uint64_t type_num, uint64_t flags) {
+    static auto real = (decltype(pmemobj_tx_xalloc)*)dlsym(RTLD_NEXT, "pmemobj_tx_xalloc");
+
+    if (real == nullptr)
+        abort();
+
+    if (tx_alloc_should_fail) {
+        errno = ENOMEM;
+        return OID_NULL;
+    }
+
+    return real(size, type_num, flags);
+}


### PR DESCRIPTION
Before libpmemobj-cpp 1.6, make_persistent used to call internally PMDK's pmemobj_tx_alloc.
After allocation flags was introduced to libpmemobj-cpp bindings, make_persistent started to use pmemobj_tx_xalloc instead.

Ref: #157 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/183)
<!-- Reviewable:end -->
