### PR TITLE
Do not include libpmemobj++ headers in pmemkv.h.

### DIFF
--- a/src/engines-experimental/tree3.h
+++ b/src/engines-experimental/tree3.h
@@ -33,6 +33,14 @@
 #pragma once
 
 #include <vector>
+#include <memory>
+#include <libpmemobj++/p.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/make_persistent_array.hpp>
+#include <libpmemobj++/transaction.hpp>
+#include <libpmemobj++/pool.hpp>
+
 #include "../pmemkv.h"
 
 using std::move;

--- a/src/engines/vcmap.cc
+++ b/src/engines/vcmap.cc
@@ -31,6 +31,7 @@
  */
 
 #include "vcmap.h"
+#include <libpmemobj++/transaction.hpp>
 
 #include <iostream>
 

--- a/src/engines/vsmap.cc
+++ b/src/engines/vsmap.cc
@@ -31,6 +31,7 @@
  */
 
 #include "vsmap.h"
+#include <libpmemobj++/transaction.hpp>
 
 #include <iostream>
 

--- a/src/pmemkv.cc
+++ b/src/pmemkv.cc
@@ -30,6 +30,13 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <libpmemobj++/make_persistent.hpp>
+#include <libpmemobj++/make_persistent_array.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
+#include <libpmemobj++/pool.hpp>
+#include <libpmemobj++/transaction.hpp>
+#include <rapidjson/document.h>
+
 #include "engines/blackhole.h"
 #include "engines-experimental/tree3.h" // todo move inside EXPERIMENTAL ifdef after cmap is available
 #include "engines/vsmap.h"

--- a/src/pmemkv.h
+++ b/src/pmemkv.h
@@ -49,12 +49,7 @@ typedef void(KVStartFailureCallback)(void* context, const char* engine, const ch
 #ifdef __cplusplus
 
 #include <string>
-#include <libpmemobj++/make_persistent.hpp>
-#include <libpmemobj++/make_persistent_array.hpp>
-#include <libpmemobj++/persistent_ptr.hpp>
-#include <libpmemobj++/pool.hpp>
-#include <libpmemobj++/transaction.hpp>
-#include "rapidjson/document.h"
+#include <functional>
 
 using std::string;
 using std::to_string;

--- a/tests/engines/vcmap_test.cc
+++ b/tests/engines/vcmap_test.cc
@@ -32,6 +32,7 @@
 
 #include "gtest/gtest.h"
 #include "../../src/engines/vcmap.h"
+#include <libpmemobj.h>
 
 using namespace pmemkv::vcmap;
 

--- a/tests/engines/vsmap_test.cc
+++ b/tests/engines/vsmap_test.cc
@@ -32,6 +32,7 @@
 
 #include "gtest/gtest.h"
 #include "../../src/engines/vsmap.h"
+#include <libpmemobj.h>
 
 using namespace pmemkv::vsmap;
 


### PR DESCRIPTION
They are not supposed to be visible to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/214)
<!-- Reviewable:end -->
