### PR TITLE
Add glibc debuginfo package to Docker images

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-28
+++ b/utils/docker/images/Dockerfile.fedora-28
@@ -65,6 +65,9 @@ RUN dnf update -y \
 	which \
 && dnf clean all
 
+# Install glibc-debuginfo
+RUN dnf debuginfo-install -y glibc
+
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh
 RUN ./install-valgrind.sh

--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -51,6 +51,7 @@ RUN apt-get update \
 	gcc \
 	g++ \
 	git \
+	libc6-dbg \
 	libdaxctl-dev \
 	libjson-c-dev \
 	libkmod-dev \


### PR DESCRIPTION
... to enable running Valgrind:

==1761== Memcheck, a memory error detector
==1761== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==1761== Using Valgrind-3.14.0 and LibVEX; rerun with -h for copyright info
==1761==

valgrind:  Fatal error at startup: a function redirection
valgrind:  which is mandatory for this platform-tool combination
valgrind:  cannot be set up.  Details of the redirection are:
valgrind:
valgrind:  A must-be-redirected function
valgrind:  whose name matches the pattern:      strlen
valgrind:  in an object with soname matching:   ld-linux-x86-64.so.2
valgrind:  was not found whilst processing
valgrind:  symbols from the object with soname: ld-linux-x86-64.so.2
valgrind:
valgrind:  Possible fixes: (1, short term): install glibc's debuginfo
valgrind:  package on this machine.  (2, longer term): ask the packagers
valgrind:  for your Linux distribution to please in future ship a non-
valgrind:  stripped ld.so (or whatever the dynamic linker .so is called)
valgrind:  that exports the above-named function using the standard
valgrind:  calling conventions for this platform.  The package you need
valgrind:  to install for fix (1) is called
valgrind:
valgrind:    On Debian, Ubuntu:                 libc6-dbg
valgrind:    On SuSE, openSuSE, Fedora, RHEL:   glibc-debuginfo
valgrind:
valgrind:  Note that if you are debugging a 32 bit process on a
valgrind:  64 bit system, you will need a corresponding 32 bit debuginfo
valgrind:  package (e.g. libc6-dbg:i386).
valgrind:
valgrind:  Cannot continue -- exiting now.  Sorry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/216)
<!-- Reviewable:end -->
