### PR TITLE
Add minor tweaks in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(TEST_FILES tests/pmemkv_test.cc tests/mock_tx_alloc.cc
 )
 
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 find_package(PkgConfig QUIET)
 include(ExternalProject)

--- a/cmake/libpmemobj++.cmake
+++ b/cmake/libpmemobj++.cmake
@@ -30,11 +30,9 @@
 
 if(PKG_CONFIG_FOUND)
 # XXX uncomment when libpmemobj-cpp 1.7 is released
-#    pkg_check_modules(LIBPMEMOBJ++ REQUIRED libpmemobj++>=1.7)
-    pkg_check_modules(LIBPMEMOBJ++ REQUIRED libpmemobj++)
+#	pkg_check_modules(LIBPMEMOBJ++ REQUIRED libpmemobj++>=1.7)
+	pkg_check_modules(LIBPMEMOBJ++ REQUIRED libpmemobj++)
 else()
-	# find_package without unsetting this var is not working correctly
-	unset(LIBPMEMOBJ++_FOUND CACHE)
 	find_package(LIBPMEMOBJ++ REQUIRED libpmemobj++)
 	message(STATUS "libpmemobj++ found the old way (w/o pkg-config)")
 endif()
@@ -48,10 +46,9 @@ CHECK_CXX_SOURCE_COMPILES(
 set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})
 
 if(NOT PMEM_STRING_PRESENT)
-	message(FATAL_ERROR "libpmemobj++/experimental/string.hpp not found (available in libpmemobj-cpp >= 1.6")
+	message(FATAL_ERROR "libpmemobj++/experimental/string.hpp not found (available in libpmemobj-cpp >= 1.6)")
 endif()
 
-# XXX make it optional?
 set(SAVED_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
 set(CMAKE_REQUIRED_INCLUDES ${LIBPMEMOBJ++_INCLUDE_DIRS})
 CHECK_CXX_SOURCE_COMPILES(


### PR DESCRIPTION
Fixes #197

- enforce no fallback to previous standard if C11 not supported (ref. https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/)
- remove unnecessary comments (one put by mistake; the other one not proper anymore, since it's not optional)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/235)
<!-- Reviewable:end -->
