### PR TITLE
docker: Add ruby package required for coverity

### DIFF
--- a/utils/docker/images/Dockerfile.ubuntu-18.04
+++ b/utils/docker/images/Dockerfile.ubuntu-18.04
@@ -65,6 +65,7 @@ RUN apt-get update \
 	numactl \
 	pkg-config \
 	rapidjson-dev \
+	ruby \
 	sudo \
 	wget \
 	whois \


### PR DESCRIPTION
this should fix Coverity scan issue, which is missing 'ruby' command

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/247)
<!-- Reviewable:end -->
