### PR TITLE
docker: Fix coverity skips with proper variable

### DIFF
--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -50,14 +50,14 @@
 set -e
 
 if [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TRAVIS_BRANCH" != "coverity_scan" \
-	&& "$COVERITY" -eq 1 ]]; then
+	&& "$TYPE" == "coverity" ]]; then
 	echo "INFO: Skip Coverity scan job if build is triggered neither by " \
 		"'cron' nor by a push to 'coverity_scan' branch"
 	exit 0
 fi
 
 if [[ ( "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BRANCH" == "coverity_scan" )\
-	&& "$COVERITY" -ne 1 ]]; then
+	&& "$TYPE" != "coverity" ]]; then
 	echo "INFO: Skip regular jobs if build is triggered either by 'cron'" \
 		" or by a push to 'coverity_scan' branch"
 	exit 0


### PR DESCRIPTION
COVERITY variable is never set, so we need to adjust usage for these 'skips' with variable TYPE=coverity

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/253)
<!-- Reviewable:end -->
