### PR TITLE
cmake: Fix for cmap engine dir checking

### DIFF
--- a/src/libpmemkv.cc
+++ b/src/libpmemkv.cc
@@ -110,6 +110,12 @@ KVEngine* KVEngine::Start(void* context, const char* engine, const char* config,
         }
 #endif
 
+#ifdef ENGINE_CMAP
+        if (engine == cmap::ENGINE) {
+            return new cmap::CMap(context, path, size);
+        }
+#endif
+
 #if defined(ENGINE_VSMAP) || defined(ENGINE_VCMAP)
         struct stat info;
         if ((stat(path, &info) < 0) || !S_ISDIR(info.st_mode)) {
@@ -126,12 +132,6 @@ KVEngine* KVEngine::Start(void* context, const char* engine, const char* config,
 #ifdef ENGINE_VCMAP
         if (engine == vcmap::ENGINE) {
             return new vcmap::VCMap(context, path, size);
-        }
-#endif
-
-#ifdef ENGINE_CMAP
-        if (engine == cmap::ENGINE) {
-            return new cmap::CMap(context, path, size);
         }
 #endif
         throw runtime_error("Unknown engine name");


### PR DESCRIPTION
When vsmap or vcmap is enabled in compilation, but we're using cmap engine it is improperly checked if cmap's path is a dir (which is not required for cmap engine).
The check for vcmap and vsmap will be moved to the place when it's used, anyway, but for now it should fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/287)
<!-- Reviewable:end -->
