### PR TITLE
Declare pmem::kv::db copy constructor/assignment operator as deleted

### DIFF
--- a/src/libpmemkv.hpp
+++ b/src/libpmemkv.hpp
@@ -71,6 +71,12 @@ public:
 	db();
 	~db();
 
+	db(const db &other) = delete;
+	db(db &&other);
+
+	db &operator=(const db &other) = delete;
+	db &operator=(db &&other);
+
 	status open(void *context, const std::string &engine_name, pmemkv_config *config);
 	status open(const std::string &engine_name, pmemkv_config *config);
 
@@ -220,6 +226,21 @@ inline db::db()
 	this->_db = nullptr;
 }
 
+inline db::db(db &&other)
+{
+	this->_db = other._db;
+	other._db = nullptr;
+}
+
+inline db &db::operator=(db &&other)
+{
+	close();
+
+	std::swap(this->_db, other._db);
+
+	return *this;
+}
+
 inline status db::open(void *context, const std::string &engine_name,
 		       pmemkv_config *config)
 {
@@ -243,8 +264,7 @@ inline void db::close()
 
 inline db::~db()
 {
-	if (this->_db != nullptr)
-		pmemkv_close(this->_db);
+	close();
 }
 
 inline status db::all_above(const std::string &key, all_callback *callback, void *arg)


### PR DESCRIPTION
and move constructor/assignment operator as defaulted. As db class holds
pointer to pmemkv_db to perform deep copy we would need to have
support in C API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/314)
<!-- Reviewable:end -->
