### PR TITLE
Don't fail pmemcheck tests if installed valgrind doesn't have pmemcheck.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -75,6 +75,11 @@ function(test cmake_file test_name test_filter tracer)
 			return()
 		endif()
 	endif()
+	if (${tracer} STREQUAL pmemcheck)
+		if (NOT VALGRIND_PMEMCHECK_FOUND)
+			return()
+		endif()
+	endif()
 
 	add_test(NAME ${test_name}
 		COMMAND ${CMAKE_COMMAND}


### PR DESCRIPTION
No distros, nor the vast majority of people outside pmem development team, have valgrind capable of pmemcheck.

#297

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/346)
<!-- Reviewable:end -->
