### PR TITLE
Make concurrent hashmap tests concurrent.

### DIFF
--- a/tests/engines/cmap_test.cc
+++ b/tests/engines/cmap_test.cc
@@ -37,9 +37,10 @@
 
 using namespace pmem::kv;
 
-const std::string PATH = "/dev/shm/pmemkv";
+std::string PATH = "/dev/shm/pmemkv";
 const size_t SIZE = 1024ull * 1024ull * 512ull;
 const size_t LARGE_SIZE = 1024ull * 1024ull * 1024ull * 2ull;
+extern const char *test_file;
 
 template <size_t POOL_SIZE>
 class CMapBaseTest : public testing::Test {
@@ -48,6 +49,8 @@ public:
 
 	CMapBaseTest()
 	{
+		if (test_file)
+			PATH = test_file;
 		std::remove(PATH.c_str());
 		Start(true);
 	}

--- a/tests/pmemkv_test.cc
+++ b/tests/pmemkv_test.cc
@@ -32,8 +32,13 @@
 
 #include "gtest/gtest.h"
 
+const char *test_file = nullptr;
+
 int main(int argc, char *argv[])
 {
+	if (argc >= 3)
+		test_file = argv[2];
+
 	::testing::InitGoogleTest(&argc, argv);
 	return RUN_ALL_TESTS();
 }

--- a/tests/run-one-test.cmake
+++ b/tests/run-one-test.cmake
@@ -33,6 +33,8 @@ include(${SRC_DIR}/helpers.cmake)
 
 setup()
 
-execute(0 ${CMAKE_CURRENT_BINARY_DIR}/pmemkv_test --gtest_filter=${TEST_NAME})
+set(TEST_FILE ${CMAKE_CURRENT_BINARY_DIR}/🗄${TEST_NAME}-${TRACER})
+
+execute(0 ${CMAKE_CURRENT_BINARY_DIR}/pmemkv_test --gtest_filter=${TEST_NAME} ${TEST_FILE})
 
 cleanup()


### PR DESCRIPTION
They all used /dev/shm/pmemkv, making tests fail unless ran with -j1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/351)
<!-- Reviewable:end -->
