### PR TITLE
Use system-installed gtest if found.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -147,7 +147,17 @@ if(ENGINE_TREE3)
 	list(APPEND TEST_FILES engines-experimental/tree3_test.cc)
 endif()
 
-include(gtest)
+find_library(GTEST NAMES gtest gtest.a)
+if(GTEST)
+	message(STATUS "Gtest found at ${GTEST}")
+	add_library(libgtest IMPORTED STATIC GLOBAL)
+	set_target_properties(libgtest PROPERTIES "IMPORTED_LOCATION" "${GTEST}"
+		"IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}")
+else()
+	message(WARNING "Gtest not installed, downloading from the Internet")
+	include(gtest)
+endif()
+
 include(get_tests.cmake)
 
 add_executable(pmemkv_test ${TEST_FILES})

--- a/utils/docker/images/Dockerfile.fedora-30
+++ b/utils/docker/images/Dockerfile.fedora-30
@@ -50,6 +50,7 @@ RUN dnf update -y \
 	gcc-c++ \
 	gdb \
 	git \
+	gtest-devel \
 	libtool \
 	make \
 	man \

--- a/utils/docker/images/Dockerfile.ubuntu-19.04
+++ b/utils/docker/images/Dockerfile.ubuntu-19.04
@@ -54,6 +54,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	git \
 	libc6-dbg \
 	libdaxctl-dev \
+	libgtest-dev \
 	libndctl-dev \
 	libnode-dev \
 	libnuma-dev \

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -100,9 +100,6 @@ function run_example_standalone() {
 
 cd $WORKDIR
 
-# copy Googletest to the current directory
-cp /opt/googletest/googletest-*.zip .
-
 # Make sure there is no libpmemkv currently installed
 echo "---------------------------- Error expected! ------------------------------"
 compile_example_standalone pmemkv_basic_cpp && exit 1


### PR DESCRIPTION
Not sure if there's any reason to download it from the network, ever.  We don't do so for any other dependency.  But for now, this commit doesn't drop downloading yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/357)
<!-- Reviewable:end -->
