### PR TITLE
Add other config options to construct tree3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,12 @@ endif()
 
 # Each engine can be enabled separately.
 # By default all experimental engines are turned off.
-option(ENGINE_VSMAP "enable vsmap engine" ON)
-option(ENGINE_VCMAP "enable vcmap engine" ON)
+option(ENGINE_VSMAP "enable vsmap engine" OFF)
+option(ENGINE_VCMAP "enable vcmap engine" OFF)
 option(ENGINE_CMAP "enable cmap engine" ON)
 option(ENGINE_CACHING "enable experimental caching engine" OFF)
 option(ENGINE_STREE "enable experimental stree engine" OFF)
-option(ENGINE_TREE3 "enable experimental tree3 engine" OFF)
+option(ENGINE_TREE3 "enable experimental tree3 engine" ON)
 
 option(DEVELOPER_MODE "enable developer's checks" OFF)
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -104,7 +104,12 @@ public:
 		return status::NOT_SUPPORTED;
 	}
 
-	virtual status get(string_view key, get_v_callback *callback, void *arg) = 0;
+    virtual status free()
+    {
+		return status::NOT_SUPPORTED;
+    }
+
+    virtual status get(string_view key, get_v_callback *callback, void *arg) = 0;
 
 	virtual status put(string_view key, string_view value) = 0;
 

--- a/src/engines-experimental/tree3.h
+++ b/src/engines-experimental/tree3.h
@@ -221,10 +221,12 @@ public:
 
 	status remove(string_view key) final;
 
+	status free() final;
+
 protected:
 	KVLeafNode *LeafSearch(const std::string &key);
 	void LeafFillEmptySlot(KVLeafNode *leafnode, uint8_t hash, const std::string &key,
-			       const std::string &value);
+						   const std::string &value);
 	bool LeafFillSlotForKey(KVLeafNode *leafnode, uint8_t hash,
 				const std::string &key, const std::string &value);
 	void LeafFillSpecificSlot(KVLeafNode *leafnode, uint8_t hash,
@@ -236,12 +238,15 @@ protected:
 				   std::string *split_key);
 	uint8_t PearsonHash(const char *data, size_t size);
 	void Recover();
+	bool IsKVOnRoot();
 
 private:
 	tree3(const tree3 &);				// prevent copying
 	void operator=(const tree3 &);			// prevent assigning
 	vector<persistent_ptr<KVLeaf>> leaves_prealloc; // persisted but unused leaves
-	pool<KVRoot> pmpool;				// pool for persistent root
+	pmem::obj::pool_base pmpool;
+	persistent_ptr<KVRoot> kvroot;
+	bool auto_close_pool;
 	unique_ptr<KVNode> tree_top;			// pointer to uppermost inner node
 };
 


### PR DESCRIPTION

These options support construct a tree3 with pmempool* and
pmemoid. The tree3 created is not on root object in this way.

The purpose of this PR is to check whether this is a valid way to construct a new tree from pmemkv team's view. 

If it is, I may start to add tests for such kind of constructors.

And is it necessary to have a free function in engine interface?


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/365)
<!-- Reviewable:end -->
