### PR TITLE
make config from json an optional case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ option(ENGINE_STREE "enable experimental stree engine" OFF)
 option(ENGINE_TREE3 "enable experimental tree3 engine" OFF)
 
 option(DEVELOPER_MODE "enable developer's checks" OFF)
+option(CONFIG_FROM_JSON "enable support to load config from json file" ON)
 
 if(ENGINE_VSMAP)
 	add_definitions(-DENGINE_VSMAP)
@@ -83,6 +84,9 @@ if(ENGINE_STREE)
 endif()
 if(ENGINE_TREE3)
 	add_definitions(-DENGINE_TREE3)
+endif()
+if(CONFIG_FROM_JSON)
+	add_definitions(-DCONFIG_FROM_JSON)
 endif()
 
 set(SOURCE_FILES
@@ -150,8 +154,11 @@ include(FindThreads)
 include(CheckCXXSourceCompiles)
 include(GNUInstallDirs)
 
-include(rapidjson)
-set(PKG_CONFIG_REQUIRES RapidJSON)
+if(CONFIG_FROM_JSON)
+	include(rapidjson)
+	set(PKG_CONFIG_REQUIRES RapidJSON)
+endif()
+
 set(DEB_DEPENDS)
 set(RPM_DEPENDS)
 
@@ -262,7 +269,10 @@ add_library(pmemkv SHARED ${SOURCE_FILES})
 target_link_libraries(pmemkv PRIVATE
 	-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/libpmemkv.map)
 
-target_link_libraries(pmemkv PRIVATE ${RapidJSON_LIBRARIES})
+if(CONFIG_FROM_JSON)
+	target_link_libraries(pmemkv PRIVATE ${RapidJSON_LIBRARIES})
+endif()
+
 if(ENGINE_VSMAP OR ENGINE_VCMAP OR ENGINE_CMAP OR ENGINE_STREE OR ENGINE_TREE3)
 	target_link_libraries(pmemkv PRIVATE ${LIBPMEMOBJ++_LIBRARIES})
 endif()

--- a/src/libpmemkv.cc
+++ b/src/libpmemkv.cc
@@ -31,10 +31,14 @@
  */
 
 #include <memory>
+
+#ifdef CONFIG_FROM_JSON
 #include <rapidjson/document.h>
 #include <rapidjson/istreamwrapper.h>
 #include <rapidjson/ostreamwrapper.h>
 #include <rapidjson/writer.h>
+#endif
+
 #include <sys/stat.h>
 
 #include "config.h"
@@ -101,6 +105,7 @@ void pmemkv_config_delete(pmemkv_config *config)
 
 int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 {
+#ifdef CONFIG_FROM_JSON
 	rapidjson::Document doc;
 	rapidjson::Value::ConstMemberIterator itr;
 
@@ -188,6 +193,10 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 	}
 
 	return PMEMKV_STATUS_OK;
+#else
+	ERR() << "pmemkv_config_from_json requires compile option CONFIG_FROM_JSON=ON";
+	return PMEMKV_STATUS_NOT_SUPPORTED;
+#endif
 }
 
 int pmemkv_config_put_data(pmemkv_config *config, const char *key, const void *value,

--- a/tests/config/json_to_config.cc
+++ b/tests/config/json_to_config.cc
@@ -55,6 +55,7 @@ TEST_F(JsonToConfigTest, SimpleTest)
 	auto ret = pmemkv_config_from_json(
 		config,
 		"{\"string\": \"abc\", \"int\": 123, \"bool\": true, \"double\": 12.43}");
+#ifdef CONFIG_FROM_JSON
 	// XXX: extend by adding "false", subconfig, negative value
 	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
 
@@ -80,4 +81,7 @@ TEST_F(JsonToConfigTest, SimpleTest)
 
 	ret = pmemkv_config_get_int64(config, "string", &value_int);
 	ASSERT_EQ(ret, PMEMKV_STATUS_CONFIG_TYPE_ERROR);
+#else
+	ASSERT_EQ(ret, PMEMKV_STATUS_NOT_SUPPORTED);
+#endif
 }


### PR DESCRIPTION
To remove one dependency RapidJSON, so users can get start with pmemkv faster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/366)
<!-- Reviewable:end -->
