### PR TITLE
Fix buffer size check in get_copy_callback

### DIFF
--- a/src/libpmemkv.cc
+++ b/src/libpmemkv.cc
@@ -614,7 +614,7 @@ static void get_copy_callback(const char *v, size_t vb, void *arg)
 	if (c->value_size != nullptr)
 		*(c->value_size) = vb;
 
-	if (vb < c->buffer_size) {
+	if (vb <= c->buffer_size) {
 		c->result = PMEMKV_STATUS_OK;
 		if (c->buffer != nullptr)
 			memcpy(c->buffer, v, vb);


### PR DESCRIPTION
issue: When buffer size passed to pmmemkv_get_copy is the same length as value,
which is legit situation, PMEMKV_STATUS_FAILED was returned.
Fix is to check if buffer size is smaller or equal than buffer for stored
value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/367)
<!-- Reviewable:end -->
