### PR TITLE
Fix gcov's excludes and set comment options

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,12 @@
 coverage:
   ignore:
+    - doc/
+    - examples/
     - utils/
+    - src/valgrind/
     - tests/
+
+comment:
+  layout: "diff, files"
+  behavior: default
+  require_changes: yes


### PR DESCRIPTION
- while checking gcov reports we've found with @marcinslusarz that some excludes were missing,
- additionally, gcov's comments were not yet added in PRs - for now I propose to display changed files and diff information; other possible options are: flags (not used in pmemkv build yet) and graph

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/369)
<!-- Reviewable:end -->
