### PR TITLE
Omit examples' execution when cmap is disabled

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -222,5 +222,11 @@ endforeach(test)
 build_example_pmemkv_basic_c()
 build_example_pmemkv_basic_cpp()
 
-test("run-binary" ex_pmemkv_basic_c ex_pmemkv_basic_c none)
-test("run-binary" ex_pmemkv_basic_cpp ex_pmemkv_basic_cpp none)
+if(ENGINE_CMAP)
+	test("run-binary" ex_pmemkv_basic_c ex_pmemkv_basic_c none)
+	test("run-binary" ex_pmemkv_basic_cpp ex_pmemkv_basic_cpp none)
+else()
+	message(WARNING
+		"Examples use cmap engine, which is disabled, hence their execution "
+		"is also disabled. If you want to run them use -DENGINE_CMAP=ON option.")
+endif()

--- a/tests/run-binary.cmake
+++ b/tests/run-binary.cmake
@@ -33,8 +33,8 @@ include(${SRC_DIR}/helpers.cmake)
 
 setup()
 
-execute_process(COMMAND ${CMAKE_COMMAND} -E remove pool${TEST_NAME})
+execute_process(COMMAND ${CMAKE_COMMAND} -E remove pool_${TEST_NAME})
 
-execute(0 ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME} pool${TEST_NAME})
+execute(0 ${CMAKE_CURRENT_BINARY_DIR}/${TEST_NAME} pool_${TEST_NAME})
 
 cleanup()


### PR DESCRIPTION
In rare case when cmap is disabled, our examples should not be built and executed.
BTW, minor change of pool name, since it's not fully readable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/379)
<!-- Reviewable:end -->
