### PR TITLE
Get rid of workaround for shallow clone on Travis

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -237,10 +237,8 @@ echo "##############################################################"
 mkdir $WORKDIR/build
 cd $WORKDIR/build
 
-# Create fake tag, so that package has proper 'version' field
-git config user.email "test@package.com"
-git config user.name "test package"
-git tag -a 0.7 -m "0.7" HEAD~1 || true
+# Fetch git history for `git describe` to work, so that package has proper 'version' field
+git fetch --unshallow --tags
 
 # Disable VCMAP and VSMAP until we'll get packages for memkind.
 cmake .. -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
Travis clone git repos with depth=50, so the tags may not be fetched.
Because of that `git describe` might not work properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/380)
<!-- Reviewable:end -->
