### PR TITLE
Add WRONG_ENGINE_NAME status

### DIFF
--- a/doc/libpmemkv.3.md.in
+++ b/doc/libpmemkv.3.md.in
@@ -212,6 +212,7 @@ Each function, except for *pmemkv_close()* and *pmemkv_errormsg()*, returns one 
 + **PMEMKV_STATUS_CONFIG_TYPE_ERROR** -- config item has different type than expected
 + **PMEMKV_STATUS_STOPPED_BY_CB** -- iteration was stopped by user's callback
 + **PMEMKV_STATUS_OUT_OF_MEMORY** -- operation failed because there is not enough memory (or space on the device)
++ **PMEMKV_STATUS_WRONG_ENGINE_NAME** -- engine name does not match any available engine
 
 # EXAMPLE #
 

--- a/src/engine.cc
+++ b/src/engine.cc
@@ -131,8 +131,8 @@ engine_base::create_engine(const std::string &engine,
 			new pmem::kv::caching(std::move(cfg)));
 #endif
 
-	throw std::runtime_error("Unknown engine name \"" + engine +
-				 "\". Available engines: " + available_engines);
+	throw internal::wrong_engine_name("Unknown engine name \"" + engine +
+					  "\". Available engines: " + available_engines);
 }
 
 status engine_base::count_all(std::size_t &cnt)

--- a/src/libpmemkv.h
+++ b/src/libpmemkv.h
@@ -49,6 +49,7 @@ extern "C" {
 #define PMEMKV_STATUS_CONFIG_TYPE_ERROR 6
 #define PMEMKV_STATUS_STOPPED_BY_CB 7
 #define PMEMKV_STATUS_OUT_OF_MEMORY 8
+#define PMEMKV_STATUS_WRONG_ENGINE_NAME 9
 
 typedef struct pmemkv_db pmemkv_db;
 typedef struct pmemkv_config pmemkv_config;

--- a/src/libpmemkv.hpp
+++ b/src/libpmemkv.hpp
@@ -102,8 +102,11 @@ enum class status {
 	STOPPED_BY_CB = PMEMKV_STATUS_STOPPED_BY_CB, /**< iteration was stopped by user's
 							callback */
 	OUT_OF_MEMORY =
-		PMEMKV_STATUS_OUT_OF_MEMORY /**< operation failed because there is not
+		PMEMKV_STATUS_OUT_OF_MEMORY, /**< operation failed because there is not
 					       enough memory (or space on the device) */
+	WRONG_ENGINE_NAME =
+		PMEMKV_STATUS_WRONG_ENGINE_NAME /**< engine name does not match any
+						   available engine */
 };
 
 class config {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -124,6 +124,32 @@ function(build_example_pmemkv_basic_c)
 	endif()
 endfunction()
 
+function(build_wrong_engine_name_test)
+	add_executable(wrong_engine_name_test wrong_engine_name_test.cc)
+	target_include_directories(wrong_engine_name_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
+	target_link_libraries(wrong_engine_name_test pmemkv)
+
+	if(ENGINE_VSMAP)
+		target_compile_definitions(wrong_engine_name_test PRIVATE -DENGINE_VSMAP)
+	endif()
+	if(ENGINE_VCMAP)
+		target_compile_definitions(wrong_engine_name_test PRIVATE -DENGINE_VCMAP)
+	endif()
+	if(ENGINE_CMAP)
+		target_compile_definitions(wrong_engine_name_test PRIVATE -DENGINE_CMAP)
+	endif()
+	if(ENGINE_CACHING)
+		target_compile_definitions(wrong_engine_name_test PRIVATE -DENGINE_CACHING)
+	endif()
+	if(ENGINE_STREE)
+		target_compile_definitions(wrong_engine_name_test PRIVATE -DENGINE_STREE)
+	endif()
+	if(ENGINE_TREE3)
+		target_compile_definitions(wrong_engine_name_test PRIVATE -DENGINE_TREE3)
+	endif()
+
+endfunction()
+
 set(TEST_FILES
 	pmemkv_test.cc
 	mock_tx_alloc.cc
@@ -223,6 +249,9 @@ endforeach(test)
 
 build_example_pmemkv_basic_c()
 build_example_pmemkv_basic_cpp()
+build_wrong_engine_name_test()
+
+test("run-binary" wrong_engine_name_test wrong_engine_name_test none)
 
 if(ENGINE_CMAP)
 	test("run-binary" ex_pmemkv_basic_c ex_pmemkv_basic_c none)

--- a/tests/wrong_engine_name_test.cc
+++ b/tests/wrong_engine_name_test.cc
@@ -30,64 +30,42 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef LIBPMEMKV_EXCEPTIONS_H
-#define LIBPMEMKV_EXCEPTIONS_H
+#include "../src/libpmemkv.hpp"
+#include <cassert>
 
-#include <stdexcept>
-
-#include "libpmemkv.h"
-
-namespace pmem
+bool test_wrong_engine_name(std::string name)
 {
-namespace kv
+	pmem::kv::db db;
+	return db.open(name) == pmem::kv::status::WRONG_ENGINE_NAME;
+}
+
+int main()
 {
-namespace internal
-{
+	assert(test_wrong_engine_name("non_existent_name"));
 
-struct error : std::runtime_error {
-	error(const std::string &msg, int status_code = PMEMKV_STATUS_FAILED)
-	    : std::runtime_error(msg), status_code(status_code)
-	{
-	}
-	int status_code;
-};
+#ifndef ENGINE_CMAP
+	assert(test_wrong_engine_name("cmap"));
+#endif
 
-struct not_supported : error {
-	not_supported(const std::string &msg) : error(msg, PMEMKV_STATUS_NOT_SUPPORTED)
-	{
-	}
-};
+#ifndef ENGINE_VSMAP
+	assert(test_wrong_engine_name("vsmap"));
+#endif
 
-struct invalid_argument : error {
-	invalid_argument(const std::string &msg)
-	    : error(msg, PMEMKV_STATUS_INVALID_ARGUMENT)
-	{
-	}
-};
+#ifndef ENGINE_VCMAP
+	assert(test_wrong_engine_name("vcmap"));
+#endif
 
-struct config_parsing_error : error {
-	config_parsing_error(const std::string &msg)
-	    : error(msg, PMEMKV_STATUS_CONFIG_PARSING_ERROR)
-	{
-	}
-};
+#ifndef ENGINE_TREE3
+	assert(test_wrong_engine_name("tree3"));
+#endif
 
-struct config_type_error : error {
-	config_type_error(const std::string &msg)
-	    : error(msg, PMEMKV_STATUS_CONFIG_TYPE_ERROR)
-	{
-	}
-};
+#ifndef ENGINE_STREE
+	assert(test_wrong_engine_name("stree"));
+#endif
 
-struct wrong_engine_name : error {
-	wrong_engine_name(const std::string &msg)
-	    : error(msg, PMEMKV_STATUS_WRONG_ENGINE_NAME)
-	{
-	}
-};
+#ifndef ENGINE_CACHING
+	assert(test_wrong_engine_name("caching"));
+#endif
 
-} /* namespace internal */
-} /* namespace kv */
-} /* namespace pmem */
-
-#endif /* LIBPMEMKV_EXCEPTIONS_H */
+	return 0;
+}

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -207,6 +207,11 @@ do
 	make -j2
 	# list all tests in this build
 	ctest -N
+	ctest -R wrong_engine_name_test --output-on-failure
+
+	if [ "$COVERAGE" == "1" ]; then
+		upload_codecov tests
+	fi
 
 	cd -
 	rm -rf $WORKDIR/build


### PR DESCRIPTION
to allow programatically handle case where selected engine is not available

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/390)
<!-- Reviewable:end -->
