### PR TITLE
Run 'git fetch --unshallow' on a shallow clone only

### DIFF
--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -234,11 +234,13 @@ echo
 echo "##############################################################"
 echo "### Verifying building of packages"
 echo "##############################################################"
+
+# Fetch git history for `git describe` to work,
+# so that package has proper 'version' field
+[ -f .git/shallow ] && git fetch --unshallow --tags
+
 mkdir $WORKDIR/build
 cd $WORKDIR/build
-
-# Fetch git history for `git describe` to work, so that package has proper 'version' field
-git fetch --unshallow --tags
 
 # Disable VCMAP and VSMAP until we'll get packages for memkind.
 cmake .. -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
The cloned repository can be a complete one,
if the building scripts are run locally
and it can cause the following error:
"fatal: --unshallow on a complete repository does not make sense".
Make sure it is a shallow clone, before running
'git fetch --unshallow'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/393)
<!-- Reviewable:end -->
