### PR TITLE
Change way of installing PMDK

### DIFF
--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -46,6 +46,7 @@ git checkout 26c86b46997d25c818b246f2a143d2248503cc67
 mkdir build
 cd build
 
+PKG_CONFIG_PATH=/usr/lib/pkgconfig/ \
 cmake .. -DCPACK_GENERATOR="$1" -DCMAKE_INSTALL_PREFIX=/usr
 make package
 if [ "$1" = "DEB" ]; then

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -38,18 +38,10 @@ set -e
 
 git clone https://github.com/pmem/pmdk
 cd pmdk
-# stable-1.6
-git checkout 695e6eba28c53a69a0ef7bad3cc0f45c21ef3e00 
+# stable-1.6: common: fix typo
+git checkout d526eb00eade98ff1caa283751c2d2dc9cf276fb
 
-make BUILD_PACKAGE_CHECK=n $1
-if [ "$1" = "dpkg" ]; then
-      sudo dpkg -i dpkg/libpmem_*.deb dpkg/libpmem-dev_*.deb
-      sudo dpkg -i dpkg/libpmemobj_*.deb dpkg/libpmemobj-dev_*.deb
-elif [ "$1" = "rpm" ]; then
-      sudo rpm -i rpm/*/pmdk-debuginfo-*.rpm
-      sudo rpm -i rpm/*/libpmem-*.rpm
-      sudo rpm -i rpm/*/libpmemobj-*.rpm
-fi
+sudo make EXTRA_CFLAGS="-DUSE_COW_ENV" -j2 install prefix=/usr
 
 cd ..
 rm -r pmdk


### PR DESCRIPTION
Currently PMDK is installed from packages.
PMDK tools (pmempool and pmreorder) are installed in the BUILDROOT
directory which is removed at the end of this script.

Change way of installing PMDK to install them in the '/usr' directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/404)
<!-- Reviewable:end -->
