### PR TITLE
Remove pmemkv_config_(put/get)_double methods

### DIFF
--- a/doc/libpmemkv_config.3.md
+++ b/doc/libpmemkv_config.3.md
@@ -60,14 +60,12 @@ int pmemkv_config_put_object(pmemkv_config *config, const char *key, void *value
 			void (*deleter)(void *));
 int pmemkv_config_put_uint64(pmemkv_config *config, const char *key, uint64_t value);
 int pmemkv_config_put_int64(pmemkv_config *config, const char *key, int64_t value);
-int pmemkv_config_put_double(pmemkv_config *config, const char *key, double value);
 int pmemkv_config_put_string(pmemkv_config *config, const char *key, const char *value);
 int pmemkv_config_get_data(pmemkv_config *config, const char *key, const void **value,
 			size_t *value_size);
 int pmemkv_config_get_object(pmemkv_config *config, const char *key, void **value);
 int pmemkv_config_get_uint64(pmemkv_config *config, const char *key, uint64_t *value);
 int pmemkv_config_get_int64(pmemkv_config *config, const char *key, int64_t *value);
-int pmemkv_config_get_double(pmemkv_config *config, const char *key, double *value);
 int pmemkv_config_get_string(pmemkv_config *config, const char *key, const char **value);
 int pmemkv_config_from_json(pmemkv_config *config, const char *jsonconfig);
 ```
@@ -82,7 +80,6 @@ of keys (null-terminated strings) to values. A value can be:
 
 + **uint64_t**
 + **int64_t**
-+ **double**
 + **c-style string**
 + **binary data**
 + **pointer to an object** (with accompanying deleter function)
@@ -107,10 +104,6 @@ Every engine has documented all supported config parameters (please see **libpme
 `int pmemkv_config_put_int64(pmemkv_config *config, const char *key, int64_t value);`
 
 :	Puts int64_t value `value` to pmemkv_config at key `key`.
-
-`int pmemkv_config_put_double(pmemkv_config *config, const char *key, double value);`
-
-:	Puts double value `value` to pmemkv_config at key `key`.
 
 `int pmemkv_config_put_string(pmemkv_config *config, const char *key, const char *value);`
 
@@ -137,11 +130,6 @@ Every engine has documented all supported config parameters (please see **libpme
 :	Gets value of a config item with key `key`. Value is copied to variable pointed by
 	`value`.
 
-`int pmemkv_config_get_double(pmemkv_config *config, const char *key, double *value);`
-
-:	Gets value of a config item with key `key`. Value is copied to variable pointed by
-	`value`.
-
 `int pmemkv_config_get_string(pmemkv_config *config, const char *key, const char **value);`
 
 :	Gets pointer to a null-terminated string. The string is not copied. After successful call
@@ -160,14 +148,14 @@ Every engine has documented all supported config parameters (please see **libpme
 
 :	Parses JSON string and puts all items found in JSON into `config`. Allowed types
 	in JSON strings and their corresponding types in pmemkv_config are:
-	+ **number** -- int64 for integral types and double for floating points,
+	+ **number** -- int64 for integral types
 	+ **string** -- const char *,
 	+ **object** -- (another JSON string) -> pointer to pmemkv_config (can be obtained using pmemkv_config_get_object)
 	+ **True**, **False** -- int64
 
 Config items stored in pmemkv_config, which were put using a specific function can be obtained
-only using corresponding pmemkv_config_get_ function (for example, config items put using pmemkv_config_put_double
-can only be obtained using pmemkv_config_get_double). Exception from this rule
+only using corresponding pmemkv_config_get_ function (for example, config items put using pmemkv_config_put_object
+can only be obtained using pmemkv_config_get_object). Exception from this rule
 are functions for uint64 and int64. If value put by pmemkv_config_put_int64 is in uint64_t range
 it can be obtained using pmemkv_config_get_uint64 and vice versa.
 

--- a/src/config.h
+++ b/src/config.h
@@ -75,11 +75,6 @@ public:
 		put(key, value);
 	}
 
-	void put_double(const char *key, double value)
-	{
-		put(key, value);
-	}
-
 	void put_string(const char *key, const char *value)
 	{
 		put(key, value);
@@ -182,26 +177,6 @@ public:
 	 * @return 'false' if no item with specified key exists,
 	 * 'true' if item was obtained successfully
 	 *
-	 * @throw pmem::kv::internal::type_error if item has type different than 'double'
-	 */
-	bool get_double(const char *key, double *value)
-	{
-		auto item = get(key);
-		if (item == nullptr)
-			return false;
-
-		if (item->item_type != type::DOUBLE)
-			throw_type_error(key, item->item_type);
-
-		*value = item->double_v;
-
-		return true;
-	}
-
-	/*
-	 * @return 'false' if no item with specified key exists,
-	 * 'true' if item was obtained successfully
-	 *
 	 * @throw pmem::kv::internal::type_error if item has type different than 'string'
 	 */
 	bool get_string(const char *key, const char **value)
@@ -238,18 +213,14 @@ public:
 	}
 
 private:
-	std::string type_names[6] = {"string", "int64", "uint64",
-				     "double", "data",  "object"};
-	enum class type { STRING, INT64, UINT64, DOUBLE, DATA, OBJECT };
+	std::string type_names[6] = {"string", "int64", "uint64", "data", "object"};
+	enum class type { STRING, INT64, UINT64, DATA, OBJECT };
 
 	struct variant {
 		variant(int64_t sint64) : sint64(sint64), item_type(type::INT64)
 		{
 		}
 		variant(uint64_t uint64) : uint64(uint64), item_type(type::UINT64)
-		{
-		}
-		variant(double double_v) : double_v(double_v), item_type(type::DOUBLE)
 		{
 		}
 		variant(const char *string_v)
@@ -279,7 +250,6 @@ private:
 		union {
 			int64_t sint64;
 			uint64_t uint64;
-			double double_v;
 			std::string string_v;
 			std::vector<char> data;
 

--- a/src/libpmemkv.cc
+++ b/src/libpmemkv.cc
@@ -149,14 +149,6 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 				if (status != PMEMKV_STATUS_OK)
 					throw std::runtime_error(
 						"Inserting int to the config failed");
-			} else if (itr->value.IsDouble()) {
-				auto value = itr->value.GetDouble();
-
-				auto status = pmemkv_config_put_double(
-					config, itr->name.GetString(), value);
-				if (status != PMEMKV_STATUS_OK)
-					throw std::runtime_error(
-						"Inserting double to the config failed");
 			} else if (itr->value.IsTrue() || itr->value.IsFalse()) {
 				auto value = itr->value.GetBool();
 
@@ -250,14 +242,6 @@ int pmemkv_config_put_uint64(pmemkv_config *config, const char *key, uint64_t va
 	});
 }
 
-int pmemkv_config_put_double(pmemkv_config *config, const char *key, double value)
-{
-	return catch_and_return_status(__func__, [&] {
-		config_to_internal(config)->put_double(key, value);
-		return PMEMKV_STATUS_OK;
-	});
-}
-
 int pmemkv_config_put_string(pmemkv_config *config, const char *key, const char *value)
 {
 	return catch_and_return_status(__func__, [&] {
@@ -298,15 +282,6 @@ int pmemkv_config_get_uint64(pmemkv_config *config, const char *key, uint64_t *v
 {
 	return catch_and_return_status(__func__, [&] {
 		return config_to_internal(config)->get_uint64(key, value)
-			? PMEMKV_STATUS_OK
-			: PMEMKV_STATUS_NOT_FOUND;
-	});
-}
-
-int pmemkv_config_get_double(pmemkv_config *config, const char *key, double *value)
-{
-	return catch_and_return_status(__func__, [&] {
-		return config_to_internal(config)->get_double(key, value)
 			? PMEMKV_STATUS_OK
 			: PMEMKV_STATUS_NOT_FOUND;
 	});

--- a/src/libpmemkv.h
+++ b/src/libpmemkv.h
@@ -66,14 +66,12 @@ int pmemkv_config_put_object(pmemkv_config *config, const char *key, void *value
 			     void (*deleter)(void *));
 int pmemkv_config_put_uint64(pmemkv_config *config, const char *key, uint64_t value);
 int pmemkv_config_put_int64(pmemkv_config *config, const char *key, int64_t value);
-int pmemkv_config_put_double(pmemkv_config *config, const char *key, double value);
 int pmemkv_config_put_string(pmemkv_config *config, const char *key, const char *value);
 int pmemkv_config_get_data(pmemkv_config *config, const char *key, const void **value,
 			   size_t *value_size);
 int pmemkv_config_get_object(pmemkv_config *config, const char *key, void **value);
 int pmemkv_config_get_uint64(pmemkv_config *config, const char *key, uint64_t *value);
 int pmemkv_config_get_int64(pmemkv_config *config, const char *key, int64_t *value);
-int pmemkv_config_get_double(pmemkv_config *config, const char *key, double *value);
 int pmemkv_config_get_string(pmemkv_config *config, const char *key, const char **value);
 int pmemkv_config_from_json(pmemkv_config *config, const char *jsonconfig);
 

--- a/src/libpmemkv.hpp
+++ b/src/libpmemkv.hpp
@@ -136,7 +136,6 @@ public:
 		void (*deleter)(void *) = [](T *value) { delete value; }) noexcept;
 	status put_uint64(const std::string &key, std::uint64_t value) noexcept;
 	status put_int64(const std::string &key, std::int64_t value) noexcept;
-	status put_double(const std::string &key, double value) noexcept;
 	status put_string(const std::string &key, const std::string &value) noexcept;
 
 	template <typename T>
@@ -147,7 +146,6 @@ public:
 
 	status get_uint64(const std::string &key, std::uint64_t &value) const noexcept;
 	status get_int64(const std::string &key, std::int64_t &value) const noexcept;
-	status get_double(const std::string &key, double &value) const noexcept;
 	status get_string(const std::string &key, std::string &value) const noexcept;
 
 	pmemkv_config *release() noexcept;
@@ -331,23 +329,6 @@ inline status config::put_int64(const std::string &key, std::int64_t value) noex
 }
 
 /**
- * Puts double value to a config.
- *
- * @param[in] key The string representing config item's name.
- * @param[in] value The double value.
- *
- * @return pmem::kv::status
- */
-inline status config::put_double(const std::string &key, double value) noexcept
-{
-	if (init() != 0)
-		return status::FAILED;
-
-	return static_cast<status>(
-		pmemkv_config_put_double(this->_config, key.data(), value));
-}
-
-/**
  * Puts string value to a config.
  *
  * @param[in] key The string representing config item's name.
@@ -449,23 +430,6 @@ inline status config::get_int64(const std::string &key, std::int64_t &value) con
 
 	return static_cast<status>(
 		pmemkv_config_get_int64(this->_config, key.data(), &value));
-}
-
-/**
- * Gets double value from a config item with key name.
- *
- * @param[in] key The string representing config item's name.
- * @param[out] value The double value.
- *
- * @return pmem::kv::status
- */
-inline status config::get_double(const std::string &key, double &value) const noexcept
-{
-	if (this->_config == nullptr)
-		return status::NOT_FOUND;
-
-	return static_cast<status>(
-		pmemkv_config_get_double(this->_config, key.data(), &value));
 }
 
 /**

--- a/src/libpmemkv.map
+++ b/src/libpmemkv.map
@@ -38,14 +38,12 @@ LIBPMEMKV_0.8 {
 		pmemkv_config_delete;
 		pmemkv_config_from_json;
 		pmemkv_config_get_data;
-		pmemkv_config_get_double;
 		pmemkv_config_get_int64;
 		pmemkv_config_get_object;
 		pmemkv_config_get_string;
 		pmemkv_config_get_uint64;
 		pmemkv_config_new;
 		pmemkv_config_put_data;
-		pmemkv_config_put_double;
 		pmemkv_config_put_int64;
 		pmemkv_config_put_object;
 		pmemkv_config_put_string;

--- a/tests/config/config_c.cc
+++ b/tests/config/config_c.cc
@@ -68,9 +68,6 @@ TEST_F(ConfigCTest, SimpleTest_TRACERS_M)
 	ret = pmemkv_config_put_int64(config, "int", 123);
 	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
 
-	ret = pmemkv_config_put_double(config, "double", 12.43);
-	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
-
 	custom_type *ptr = new custom_type;
 	ptr->a = 10;
 	ptr->b = 'a';
@@ -96,11 +93,6 @@ TEST_F(ConfigCTest, SimpleTest_TRACERS_M)
 	ret = pmemkv_config_get_int64(config, "int", &value_int);
 	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
 	ASSERT_EQ(value_int, 123);
-
-	double value_double;
-	ret = pmemkv_config_get_double(config, "double", &value_double);
-	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
-	ASSERT_EQ(value_double, 12.43);
 
 	custom_type *value_custom_ptr;
 	ret = pmemkv_config_get_object(config, "object_ptr", (void **)&value_custom_ptr);
@@ -206,10 +198,6 @@ TEST_F(ConfigCTest, NotFoundTest_TRACERS_M)
 
 	size_t my_uint;
 	ret = pmemkv_config_get_uint64(config, "non-existent-uint", &my_uint);
-	ASSERT_EQ(ret, PMEMKV_STATUS_NOT_FOUND);
-
-	double value_double;
-	ret = pmemkv_config_get_double(config, "non-existent-double", &value_double);
 	ASSERT_EQ(ret, PMEMKV_STATUS_NOT_FOUND);
 
 	custom_type *my_object;

--- a/tests/config/config_cpp.cc
+++ b/tests/config/config_cpp.cc
@@ -70,9 +70,6 @@ TEST_F(ConfigCppTest, SimpleTest_TRACERS_M)
 	s = cfg->put_int64("int", 123);
 	ASSERT_EQ(s, status::OK);
 
-	s = cfg->put_double("double", 12.43);
-	ASSERT_EQ(s, status::OK);
-
 	custom_type *ptr = new custom_type;
 	ptr->a = 10;
 	ptr->b = 'a';
@@ -102,11 +99,6 @@ TEST_F(ConfigCppTest, SimpleTest_TRACERS_M)
 	s = cfg->get_int64("int", value_int);
 	ASSERT_EQ(s, status::OK);
 	ASSERT_EQ(value_int, 123);
-
-	double value_double;
-	s = cfg->get_double("double", value_double);
-	ASSERT_EQ(s, status::OK);
-	ASSERT_EQ(value_double, 12.43);
 
 	custom_type *value_custom_ptr;
 	s = cfg->get_object("object_ptr", value_custom_ptr);
@@ -243,14 +235,12 @@ TEST_F(ConfigCppTest, NotFoundTest_TRACERS_M)
 	std::string my_string;
 	int64_t my_int;
 	uint64_t my_uint;
-	double my_double;
 	custom_type *my_object;
 	size_t my_object_count = 0;
 
 	ASSERT_EQ(cfg->get_string("string", my_string), status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_int64("int", my_int), status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_uint64("uint", my_uint), status::NOT_FOUND);
-	ASSERT_EQ(cfg->get_double("double", my_double), status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_object("object", my_object), status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_data("data", my_object, my_object_count), status::NOT_FOUND);
 	ASSERT_EQ(my_object_count, 0);
@@ -262,7 +252,6 @@ TEST_F(ConfigCppTest, NotFoundTest_TRACERS_M)
 	ASSERT_EQ(cfg->get_string("non-existent-string", my_string), status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_int64("non-existent-int", my_int), status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_uint64("non-existent-uint", my_uint), status::NOT_FOUND);
-	ASSERT_EQ(cfg->get_double("non-existent-double", my_double), status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_object("non-existent-object_ptr", my_object),
 		  status::NOT_FOUND);
 	ASSERT_EQ(cfg->get_data("non-existent-data", my_object, my_object_count),

--- a/tests/config/json_to_config.cc
+++ b/tests/config/json_to_config.cc
@@ -51,8 +51,7 @@ public:
 TEST_F(JsonToConfigTest, SimpleTest_TRACERS_M)
 {
 	auto ret = pmemkv_config_from_json(
-		config,
-		"{\"string\": \"abc\", \"int\": 123, \"bool\": true, \"double\": 12.43}");
+		config, "{\"string\": \"abc\", \"int\": 123, \"bool\": true}");
 #ifdef CONFIG_FROM_JSON
 	// XXX: extend by adding "false", subconfig, negative value
 	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
@@ -72,13 +71,18 @@ TEST_F(JsonToConfigTest, SimpleTest_TRACERS_M)
 	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
 	ASSERT_EQ(value_bool, 1);
 
-	double value_double;
-	ret = pmemkv_config_get_double(config, "double", &value_double);
-	ASSERT_EQ(ret, PMEMKV_STATUS_OK);
-	ASSERT_EQ(value_double, 12.43);
-
 	ret = pmemkv_config_get_int64(config, "string", &value_int);
 	ASSERT_EQ(ret, PMEMKV_STATUS_CONFIG_TYPE_ERROR);
+#else
+	ASSERT_EQ(ret, PMEMKV_STATUS_NOT_SUPPORTED);
+#endif
+}
+
+TEST_F(JsonToConfigTest, DoubleTest_TRACERS_M)
+{
+	auto ret = pmemkv_config_from_json(config, "{\"double\": 12.34}");
+#ifdef CONFIG_FROM_JSON
+	ASSERT_EQ(ret, PMEMKV_STATUS_CONFIG_PARSING_ERROR);
 #else
 	ASSERT_EQ(ret, PMEMKV_STATUS_NOT_SUPPORTED);
 #endif


### PR DESCRIPTION
Currently there is no use case for those methods. Additionaly
it is problemtatic for untyped languages (e.g. JS) to properly handle
numeric values. Having just int64/uint64 allows to always treat numbers
as intgers.