### PR TITLE
Tweak parameters for stree and tree3 tests

### DIFF
--- a/tests/basic_tests.h
+++ b/tests/basic_tests.h
@@ -91,14 +91,14 @@ static Basic basic_tests[] = {
 #endif // ENGINE_VCMAP
 #ifdef ENGINE_TREE3
 	{
-		.path = "/dev/shm",
+		.path = "/dev/shm/file",
 		.size = (uint64_t)(1024 * 1024 * 1024),
 		.force_create = 1,
 		.engine = "tree3",
 		.key_length = 100,
 		.value_length = 100,
 		.test_data_size = 20,
-		.pretest_remove_path = false,
+		.pretest_remove_path = true,
 		.name = "Tree3TestShm100bKey100bValue",
 		.tracers = "",
 	},
@@ -106,14 +106,14 @@ static Basic basic_tests[] = {
 
 #ifdef ENGINE_STREE
 	{
-		.path = "/dev/shm",
+		.path = "/dev/shm/file",
 		.size = (uint64_t)(1024 * 1024 * 1024),
 		.force_create = 1,
 		.engine = "stree",
-		.key_length = 100,
-		.value_length = 100,
+		.key_length = 20,
+		.value_length = 200,
 		.test_data_size = 20,
-		.pretest_remove_path = false,
+		.pretest_remove_path = true,
 		.name = "StreeTestShm100bKey100bValue",
 		.tracers = "",
 	},


### PR DESCRIPTION
* stree and tree3 should get file instead of directory as path seting
* Max key length (hardcoded in engine) is 20
* Max value length (hardcoded in engine) is 200
* Pretest cleanup enabled for those engines