### PR TITLE
Minor caching engine fixes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -242,6 +242,8 @@ if(ENGINE_CMAP)
 	target_link_libraries(pmemkv_test ${LIBPMEMOBJ++_LIBRARIES})
 endif()
 if(ENGINE_CACHING)
+	# caching tests require lib_acl and memcached included, so we need to link
+	# them to test binary itself
 	target_link_libraries(pmemkv_test memcached)
 	target_link_libraries(pmemkv_test acl_cpp protocol acl)
 endif()

--- a/tests/engines-experimental/caching_test.cc
+++ b/tests/engines-experimental/caching_test.cc
@@ -193,8 +193,8 @@ TEST_F(CachingTest, SimpleMemcached)
 	const char *key = "key1";
 	const char *value1 = "value1";
 
-	memcached_server_st *memcached_servers_parse(char *server_strings);
 	memc = memcached_create(NULL);
+	// XXX: need to check if server doesn't exist already
 	servers = memcached_server_list_append(servers, (char *)"127.0.0.1", 11211, &rc);
 	rc = memcached_server_push(memc, servers);
 	if (rc == MEMCACHED_SUCCESS)
@@ -247,7 +247,6 @@ TEST_F(CachingTest, UnknownLocalMemcachedKey)
 	uint32_t flags;
 	size_t return_value_length;
 
-	memcached_server_st *memcached_servers_parse(char *server_strings);
 	memc = memcached_create(NULL);
 	servers = memcached_server_list_append(servers, (char *)"127.0.0.1", 11211, &rc);
 	rc = memcached_server_push(memc, servers);
@@ -745,7 +744,6 @@ TEST_F(CachingTest, Memcached_Integration)
 	const int key_length = 4;
 	const int value_length = 6;
 
-	memcached_server_st *memcached_servers_parse(char *server_strings);
 	memc = memcached_create(NULL);
 	servers = memcached_server_list_append(servers, (char *)"127.0.0.1", 11211, &rc);
 	rc = memcached_server_push(memc, servers);


### PR DESCRIPTION
- minor caching cleanup
- add explanation for second linking of memcached and libacl to pmemkv_tests

part of the old PR: #378

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/411)
<!-- Reviewable:end -->
