### PR TITLE
Fix errormsg()

### DIFF
--- a/src/out.cc
+++ b/src/out.cc
@@ -40,7 +40,7 @@ static thread_local std::string str;
 
 std::ostream &out_err_stream(const char *func)
 {
-	error_stream.clear();
+	error_stream.str(std::string());
 
 	error_stream << "[" << func << "] ";
 

--- a/tests/engines/blackhole_test.cc
+++ b/tests/engines/blackhole_test.cc
@@ -65,3 +65,20 @@ TEST_F(BlackholeTest, SimpleTest_TRACERS_MP)
 	ASSERT_TRUE(kv.remove("key1") == status::OK);
 	ASSERT_TRUE(kv.get("key1", &value) == status::NOT_FOUND);
 }
+
+TEST_F(BlackholeTest, ErrormsgTest)
+{
+	auto s = kv.open("non-existing name");
+	ASSERT_TRUE(s == pmem::kv::status::WRONG_ENGINE_NAME);
+
+	auto err = pmem::kv::errormsg();
+	ASSERT_TRUE(err.size() > 0);
+
+	s = kv.open("non-existing name");
+	ASSERT_TRUE(s == pmem::kv::status::WRONG_ENGINE_NAME);
+	s = kv.open("non-existing name");
+	ASSERT_TRUE(s == pmem::kv::status::WRONG_ENGINE_NAME);
+
+	/* Test whether errormsg is cleared correctly after each error */
+	ASSERT_TRUE(pmem::kv::errormsg() == err);
+}


### PR DESCRIPTION
Internal errormsg string was cleared incorrectly. This resulted in
errormsg being concatenated string from all previous errors.

This patch fixes this issue and adds a test.

Fixes: https://github.com/pmem/pmemkv/issues/432

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/433)
<!-- Reviewable:end -->
