### PR TITLE
Fix linking to pmemkv when not installed in sys path

### DIFF
--- a/examples/pmemkv_basic_c/CMakeLists.txt
+++ b/examples/pmemkv_basic_c/CMakeLists.txt
@@ -39,5 +39,7 @@ else()
 	message(FATAL_ERROR "pkg-config not found")
 endif()
 
+include_directories(${LIBPMEMKV_INCLUDE_DIRS})
+link_directories(${LIBPMEMKV_LIBRARY_DIRS})
 add_executable(pmemkv_basic_c pmemkv_basic.c)
 target_link_libraries(pmemkv_basic_c ${LIBPMEMKV_LIBRARIES})

--- a/examples/pmemkv_basic_cpp/CMakeLists.txt
+++ b/examples/pmemkv_basic_cpp/CMakeLists.txt
@@ -39,5 +39,7 @@ else()
 	message(FATAL_ERROR "pkg-config not found")
 endif()
 
+include_directories(${LIBPMEMKV_INCLUDE_DIRS})
+link_directories(${LIBPMEMKV_LIBRARY_DIRS})
 add_executable(pmemkv_basic_cpp pmemkv_basic.cpp)
 target_link_libraries(pmemkv_basic_cpp ${LIBPMEMKV_LIBRARIES})

--- a/examples/pmemkv_config_c/CMakeLists.txt
+++ b/examples/pmemkv_config_c/CMakeLists.txt
@@ -39,5 +39,7 @@ else()
 	message(FATAL_ERROR "pkg-config not found")
 endif()
 
+include_directories(${LIBPMEMKV_INCLUDE_DIRS})
+link_directories(${LIBPMEMKV_LIBRARY_DIRS})
 add_executable(pmemkv_config_c pmemkv_config.c)
 target_link_libraries(pmemkv_config_c ${LIBPMEMKV_LIBRARIES})

--- a/examples/pmemkv_pmemobj_cpp/CMakeLists.txt
+++ b/examples/pmemkv_pmemobj_cpp/CMakeLists.txt
@@ -42,5 +42,7 @@ else()
 	message(FATAL_ERROR "pkg-config not found")
 endif()
 
+include_directories(${LIBPMEMKV_INCLUDE_DIRS})
+link_directories(${LIBPMEMKV_LIBRARY_DIRS})
 add_executable(pmemkv_pmemobj_basic_cpp pmemkv_pmemobj_basic.cpp)
 target_link_libraries(pmemkv_pmemobj_basic_cpp ${LIBPMEMKV_LIBRARIES} ${LIBPMEMOBJ++_LIBRARIES})


### PR DESCRIPTION
Link to libpmemkv installed in custom path was broken in examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/460)
<!-- Reviewable:end -->
