### PR TITLE
cmap: remove define which enable tbb locks in hash_map

### DIFF
--- a/src/engines/cmap.h
+++ b/src/engines/cmap.h
@@ -35,9 +35,8 @@
 #include "../pmemobj_engine.h"
 #include "../polymorphic_string.h"
 
-#include <libpmemobj++/persistent_ptr.hpp>
-#define LIBPMEMOBJ_CPP_USE_TBB_RW_MUTEX 1
 #include <libpmemobj++/experimental/concurrent_hash_map.hpp>
+#include <libpmemobj++/persistent_ptr.hpp>
 
 namespace pmem
 {


### PR DESCRIPTION
This define has no effect currently, as hashmap uses template locks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/468)
<!-- Reviewable:end -->
