### PR TITLE
Fix finding memkind package using find_path

### DIFF
--- a/cmake/memkind.cmake
+++ b/cmake/memkind.cmake
@@ -33,6 +33,9 @@ if(PKG_CONFIG_FOUND)
 endif()
 
 if(NOT MEMKIND_FOUND)
+	unset(MEMKIND_LIBRARY CACHE)
+	unset(MEMKIND_INCLUDEDIR CACHE)
+
 	# try old method
 	include(FindPackageHandleStandardArgs)
 	find_path(MEMKIND_INCLUDEDIR pmem_allocator.h)


### PR DESCRIPTION
Finding memkind using find_path and find_library did not work because
MEMKIND_INCLUDEDIR was also set by pkg_check_modules which resulted in
a conflict.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/489)
<!-- Reviewable:end -->
