### PR TITLE
Use >= not > in "memkind too old" message.

### DIFF
--- a/cmake/memkind.cmake
+++ b/cmake/memkind.cmake
@@ -69,6 +69,7 @@ set(CMAKE_REQUIRED_INCLUDES ${SAVED_CMAKE_REQUIRED_INCLUDES})
 if(LIBMEMKIND_NAMESPACE_PRESENT)
 	add_definitions(-DUSE_LIBMEMKIND_NAMESPACE)
 else()
-	message(STATUS "libmemkind namespace not found (available in memkind > 1.9.0). "
-					"Old namespace will be used for 'pmem::allocator'.")
+	message(STATUS "libmemkind namespace not found (available in memkind >= 1.10; "
+		"not yet released at this time; you want at least commit 3f321feb). "
+		"Old namespace will be used for 'pmem::allocator'.")
 endif()


### PR DESCRIPTION
The latter can fool inattentive readers.  It'd also be wrong if for some
reason a point release of memkind 1.9 happens.

Fixes #487.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/490)
<!-- Reviewable:end -->
