### PR TITLE
Skip valgrind and pmemcheck tests if they are not installed

### DIFF
--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -28,6 +28,8 @@ are logged as GitHub issues.*
 * [RapidJSON](https://github.com/tencent/rapidjson) - JSON parser (required by `libpmemkv_json_config` helper library)
 * Used only for development & testing:
 	* [GoogleTest](https://github.com/google/googletest) - test framework, version >= 1.8
+	* [valgrind](https://github.com/pmem/valgrind) - tool for profiling and memory leak detection. *pmem* forked version with *pmemcheck*
+		tool is recommended, but upstream/original [valgrind](http://valgrind.org/) is also compatible (package valgrind-devel is required).
 	* [pandoc](https://pandoc.org/) - markup converter to generate manpages
 	* [doxygen](http://www.doxygen.nl/) - tool for generating documentation from annotated C++ sources
 	* [graphviz](https://www.graphviz.org/) - graph visualization software required by _doxygen_

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -235,24 +235,27 @@ endif()
 include(Dart)
 include(GoogleTest)
 add_executable(pmemkv_test ${TEST_FILES})
-
-add_executable(memcheck valgrind_wrapper.cc)
-add_dependencies(memcheck pmemkv_test)
-
-add_executable(pmemcheck valgrind_wrapper.cc)
-add_dependencies(pmemcheck pmemkv_test)
-
-add_executable(drd valgrind_wrapper.cc)
-add_dependencies(drd pmemkv_test)
-
-add_executable(helgrind valgrind_wrapper.cc)
-add_dependencies(helgrind pmemkv_test)
-
 gtest_discover_tests(pmemkv_test EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES)
-gtest_discover_tests(memcheck EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _MEMCHECK)
-gtest_discover_tests(pmemcheck EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _PMEMCHECK)
-gtest_discover_tests(drd EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _DRD)
-gtest_discover_tests(helgrind EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _HELGRIND)
+
+if (VALGRIND_FOUND AND NOT COVERAGE)
+	add_executable(memcheck valgrind_wrapper.cc)
+	add_dependencies(memcheck pmemkv_test)
+	gtest_discover_tests(memcheck EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _MEMCHECK)
+
+	add_executable(drd valgrind_wrapper.cc)
+	add_dependencies(drd pmemkv_test)
+	gtest_discover_tests(drd EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _DRD)
+
+	add_executable(helgrind valgrind_wrapper.cc)
+	add_dependencies(helgrind pmemkv_test)
+	gtest_discover_tests(helgrind EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _HELGRIND)
+endif()
+
+if (VALGRIND_PMEMCHECK_FOUND AND NOT COVERAGE)
+	add_executable(pmemcheck valgrind_wrapper.cc)
+	add_dependencies(pmemcheck pmemkv_test)
+	gtest_discover_tests(pmemcheck EXTRA_ARGS --test_dir ${TEST_DIR} NO_PRETTY_VALUES TEST_SUFFIX _PMEMCHECK)
+endif()
 
 target_link_libraries(pmemkv_test pmemkv libgtest ${CMAKE_DL_LIBS})
 
@@ -299,6 +302,6 @@ elseif(BUILD_EXAMPLES AND NOT ENGINE_CMAP)
 endif()
 
 # test pmreorder framework
-if(PMREORDER)
+if(PMREORDER_SUPPORTED)
 	test("run-pmreorder-test" wrong_engine_name_test-pmreorder wrong_engine_name_test pmreorder)
 endif()


### PR DESCRIPTION
New test framework doesn't skip tests when valgrind or pmemcheck are not available.

Fixes #488 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/493)
<!-- Reviewable:end -->
