### PR TITLE
Always use current version of pmemkv in manpages

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -66,25 +66,29 @@ if(PANDOC)
 		COMMAND ${CMAKE_SOURCE_DIR}/utils/md2man/md2man.sh
 			${CMAKE_SOURCE_DIR}/doc/libpmemkv.7.md
 			${CMAKE_SOURCE_DIR}/utils/md2man/default.man
-			${CMAKE_BINARY_DIR}/man/libpmemkv.7)
+			${CMAKE_BINARY_DIR}/man/libpmemkv.7
+			${VERSION})
 	add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/man/libpmemkv.3
 		MAIN_DEPENDENCY ${CMAKE_BINARY_DIR}/man/tmp/libpmemkv.3.md
 		COMMAND ${CMAKE_SOURCE_DIR}/utils/md2man/md2man.sh
 			${CMAKE_BINARY_DIR}/man/tmp/libpmemkv.3.md
 			${CMAKE_SOURCE_DIR}/utils/md2man/default.man
-			${CMAKE_BINARY_DIR}/man/libpmemkv.3)
+			${CMAKE_BINARY_DIR}/man/libpmemkv.3
+			${VERSION})
 	add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/man/libpmemkv_config.3
 		MAIN_DEPENDENCY ${CMAKE_BINARY_DIR}/man/tmp/libpmemkv_config.3.md
 		COMMAND ${CMAKE_SOURCE_DIR}/utils/md2man/md2man.sh
 			${CMAKE_BINARY_DIR}/man/tmp/libpmemkv_config.3.md
 			${CMAKE_SOURCE_DIR}/utils/md2man/default.man
-			${CMAKE_BINARY_DIR}/man/libpmemkv_config.3)
+			${CMAKE_BINARY_DIR}/man/libpmemkv_config.3
+			${VERSION})
 	add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/man/libpmemkv_json_config.3
 		MAIN_DEPENDENCY ${CMAKE_SOURCE_DIR}/doc/libpmemkv_json_config.3.md
 		COMMAND ${CMAKE_SOURCE_DIR}/utils/md2man/md2man.sh
 			${CMAKE_SOURCE_DIR}/doc/libpmemkv_json_config.3.md
 			${CMAKE_SOURCE_DIR}/utils/md2man/default.man
-			${CMAKE_BINARY_DIR}/man/libpmemkv_json_config.3)
+			${CMAKE_BINARY_DIR}/man/libpmemkv_json_config.3
+			${VERSION})
 
 	# install manpages
 	install(FILES ${CMAKE_BINARY_DIR}/man/libpmemkv.7

--- a/doc/libpmemkv.3.md.in
+++ b/doc/libpmemkv.3.md.in
@@ -4,7 +4,7 @@ Content-Style: 'text/css'
 title: _MP(PMEMKV, 3)
 collection: libpmemkv
 header: PMEMKV
-date: pmemkv version 1.0.1
+secondary_title: pmemkv
 ...
 
 [comment]: <> (Copyright 2019, Intel Corporation)

--- a/doc/libpmemkv.7.md
+++ b/doc/libpmemkv.7.md
@@ -4,7 +4,7 @@ Content-Style: 'text/css'
 title: _MP(PMEMKV, 7)
 collection: libpmemkv
 header: PMEMKV
-date: pmemkv version 1.0.1
+secondary_title: pmemkv
 ...
 
 [comment]: <> (Copyright 2019, Intel Corporation)

--- a/doc/libpmemkv_config.3.md.in
+++ b/doc/libpmemkv_config.3.md.in
@@ -4,7 +4,7 @@ Content-Style: 'text/css'
 title: _MP(PMEMKV_CONFIG, 3)
 collection: libpmemkv
 header: PMEMKV_CONFIG
-date: pmemkv version 1.0.1
+secondary_title: pmemkv
 ...
 
 [comment]: <> (Copyright 2019, Intel Corporation)

--- a/doc/libpmemkv_json_config.3.md
+++ b/doc/libpmemkv_json_config.3.md
@@ -4,7 +4,7 @@ Content-Style: 'text/css'
 title: _MP(PMEMKV_JSON_CONFIG, 3)
 collection: libpmemkv
 header: PMEMKV_JSON_CONFIG
-date: pmemkv_json_config version 1.0.1
+secondary_title: pmemkv_json_config
 ...
 
 [comment]: <> (Copyright 2019, Intel Corporation)

--- a/utils/md2man/default.man
+++ b/utils/md2man/default.man
@@ -8,7 +8,7 @@ $endif$
 $if(adjusting)$
 .ad $adjusting$
 $endif$
-.TH "$title$" "$section$" "$date$" "PMEMKV - $version$" "PMEMKV Programmer's Manual"
+.TH "$title$" "$section$" "$date$" "PMEMKV - $secondary_title$ version $version$" "PMEMKV Programmer's Manual"
 $if(hyphenate)$
 .hy
 $else$

--- a/utils/md2man/md2man.sh
+++ b/utils/md2man/md2man.sh
@@ -50,9 +50,10 @@ set -o pipefail
 filename=$1
 template=$2
 outfile=$3
+version=$4
 title=`sed -n 's/^title:\ _MP(*\([A-Za-z_-]*\).*$/\1/p' $filename`
 section=`sed -n 's/^title:.*\([0-9]\))$/\1/p' $filename`
-version=`sed -n 's/^date:\ *\(.*\)$/\1/p' $filename`
+secondary_title=`sed -n 's/^secondary_title:\ *\(.*\)$/\1/p' $filename`
 
 dt="$(date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%F)"
 # since genereted docs are not kept in the repo the output dir may not exist
@@ -63,7 +64,7 @@ cat $filename | sed -n -e '/# NAME #/,$p' |\
 	pandoc -s -t man -o $outfile --template=$template \
 	-V title=$title -V section=$section \
 	-V date="$dt" -V version="$version" \
-	-V year=$(date +"%Y") |
+	-V year=$(date +"%Y") -V secondary_title="$secondary_title" |
 sed '/^\.IP/{
 N
 /\n\.nf/{


### PR DESCRIPTION
md2man is changed to get additional parameter with current version, which
is setup e.g. in CMake. This way we can use non-hardcoded version in manpages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/508)
<!-- Reviewable:end -->
