### PR TITLE
make the build reproducible

### DIFF
--- a/utils/md2man/md2man.sh
+++ b/utils/md2man/md2man.sh
@@ -54,7 +54,7 @@ title=`sed -n 's/^title:\ _MP(*\([A-Za-z_-]*\).*$/\1/p' $filename`
 section=`sed -n 's/^title:.*\([0-9]\))$/\1/p' $filename`
 version=`sed -n 's/^date:\ *\(.*\)$/\1/p' $filename`
 
-dt=$(date +"%F")
+dt="$(date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%F)"
 # since genereted docs are not kept in the repo the output dir may not exist
 out_dir=`echo $outfile | sed 's/\(.*\)\/.*/\1/'`
 mkdir -p $out_dir


### PR DESCRIPTION
From [Debian bug #943829](https://bugs.debian.org/943829):
> Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) we noticed that pmemkv could not be built reproducibly. This is because it uses the current build date when generating the manpages.
>
> Patch attached that will use [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch/) where set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/520)
<!-- Reviewable:end -->
