### PR TITLE
Always look for libpmemobj-cpp package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -196,12 +196,10 @@ set(PKG_CONFIG_REQUIRES)
 set(DEB_DEPENDS)
 set(RPM_DEPENDS)
 
-if(ENGINE_VSMAP OR ENGINE_VCMAP OR ENGINE_CMAP OR ENGINE_STREE OR ENGINE_TREE3)
-	include(libpmemobj++)
-	list(APPEND PKG_CONFIG_REQUIRES "libpmemobj++ >= ${LIBPMEMOBJ_CPP_REQUIRED_VERSION}")
-	list(APPEND RPM_DEPENDS "libpmemobj >= ${LIBPMEMOBJ_REQUIRED_VERSION}")
-	list(APPEND DEB_DEPENDS "libpmemobj1 (>= ${LIBPMEMOBJ_REQUIRED_VERSION}) | libpmemobj (>= ${LIBPMEMOBJ_REQUIRED_VERSION})")
-endif()
+include(libpmemobj++)
+list(APPEND PKG_CONFIG_REQUIRES "libpmemobj++ >= ${LIBPMEMOBJ_CPP_REQUIRED_VERSION}")
+list(APPEND RPM_DEPENDS "libpmemobj >= ${LIBPMEMOBJ_REQUIRED_VERSION}")
+list(APPEND DEB_DEPENDS "libpmemobj1 (>= ${LIBPMEMOBJ_REQUIRED_VERSION}) | libpmemobj (>= ${LIBPMEMOBJ_REQUIRED_VERSION})")
 
 if(ENGINE_VSMAP OR ENGINE_VCMAP)
 	include(memkind)
@@ -288,9 +286,7 @@ set_target_properties(pmemkv PROPERTIES SOVERSION 1)
 target_link_libraries(pmemkv PRIVATE
 	-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/libpmemkv.map)
 
-if(ENGINE_VSMAP OR ENGINE_VCMAP OR ENGINE_CMAP OR ENGINE_STREE OR ENGINE_TREE3)
-	target_link_libraries(pmemkv PRIVATE ${LIBPMEMOBJ++_LIBRARIES})
-endif()
+target_link_libraries(pmemkv PRIVATE ${LIBPMEMOBJ++_LIBRARIES})
 if(ENGINE_VSMAP OR ENGINE_VCMAP)
 	target_link_libraries(pmemkv PRIVATE ${MEMKIND_LIBRARIES})
 endif()

--- a/ENGINES-experimental.md
+++ b/ENGINES-experimental.md
@@ -41,7 +41,7 @@ a given key. Leaf modifications are accelerated using
 
 ### Prerequisites
 
-Libpmemobj-cpp package is required.
+No additional packages are required.
 
 
 # stree
@@ -65,7 +65,7 @@ It is disabled by default. It can be enabled in CMake using the `ENGINE_STREE` o
 
 ### Prerequisites
 
-Libpmemobj-cpp package is required.
+No additional packages are required.
 
 
 # caching

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -22,7 +22,7 @@ are logged as GitHub issues.*
 
 * 64-bit Linux (OSX and Windows are not yet supported)
 * [PMDK](https://github.com/pmem/pmdk) - Persistent Memory Development Kit 1.7
-* [libpmemobj-cpp](https://github.com/pmem/libpmemobj-cpp) - C++ bindings 1.8 for PMDK (required by all engines except blackhole and caching)
+* [libpmemobj-cpp](https://github.com/pmem/libpmemobj-cpp) - C++ bindings 1.8 for PMDK
 * [memkind](https://github.com/memkind/memkind) - Volatile memory manager 1.8.0 (required by vsmap & vcmap engines)
 * [TBB](https://github.com/01org/tbb) - Thread Building Blocks (required by vcmap engine)
 * [RapidJSON](https://github.com/tencent/rapidjson) - JSON parser (required by `libpmemkv_json_config` helper library)

--- a/doc/libpmemkv.7.md
+++ b/doc/libpmemkv.7.md
@@ -83,7 +83,6 @@ A persistent concurrent engine, backed by a hashmap that allows calling get, put
 Data stored using this engine is persistent and guaranteed to be consistent in case of any kind of interruption (crash / power loss / etc).
 
 Internally this engine uses persistent concurrent hashmap and persistent string from libpmemobj-cpp library (for details see <https://github.com/pmem/libpmemobj-cpp>). Persistent string is used as a type of a key and a value. Engine's functions should not be called within libpmemobj transactions (improper call by user will result thrown exception).
-libpmemobj-cpp packages are required.
 
 This engine requires the following config parameters (see **libpmemkv_config**(3) for details how to set them):
 
@@ -114,7 +113,7 @@ When using **pmempool create**, "pmemkv" should be passed as layout. Only PMEMOB
 A volatile concurrent engine, backed by memkind. Data written using this engine is lost after database is closed.
 
 This engine is built on top of tbb::concurrent\_hash\_map data structure and uses PMEM C++ allocator to allocate memory. std::basic\_string is used as a type of a key and a value.
-Memkind, TBB and libpmemobj-cpp packages are required.
+Memkind and TBB packages are required.
 
 This engine requires the following config parameters (see **libpmemkv_config**(3) for details how to set them):
 
@@ -129,7 +128,7 @@ This engine requires the following config parameters (see **libpmemkv_config**(3
 A volatile single-threaded sorted engine, backed by memkind. Data written using this engine is lost after database is closed.
 
 This engine is built on top of std::map and uses PMEM C++ allocator to allocate memory. std::basic\_string is used as a type of a key and a value.
-Memkind and libpmemobj-cpp packages are required.
+Memkind package is required.
 
 This engine requires the following config parameters (see **libpmemkv_config**(3) for details how to set them):
 


### PR DESCRIPTION
It's because we use pexceptions.hpp in libpmemkv.cc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/522)
<!-- Reviewable:end -->
