### PR TITLE
Add skip flags for additional artifacts builds/installs in Dockerfiles

### DIFF
--- a/utils/docker/images/Dockerfile.archlinux-base-latest
+++ b/utils/docker/images/Dockerfile.archlinux-base-latest
@@ -38,6 +38,11 @@
 FROM archlinux/base:latest
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the pacman cache and install basic tools
 RUN pacman -Syu --noconfirm
 RUN pacman -S --noconfirm \

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -38,6 +38,11 @@
 FROM centos:8
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 RUN dnf update -y
 RUN dnf install -y epel-release
 RUN dnf install -y 'dnf-command(config-manager)'

--- a/utils/docker/images/Dockerfile.debian-testing
+++ b/utils/docker/images/Dockerfile.debian-testing
@@ -38,6 +38,11 @@
 FROM debian:testing
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/utils/docker/images/Dockerfile.debian-unstable
+++ b/utils/docker/images/Dockerfile.debian-unstable
@@ -38,6 +38,11 @@
 FROM debian:unstable
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -38,6 +38,11 @@
 FROM fedora:31
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Install basic tools
 RUN dnf update -y \
  && dnf install -y \

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -38,6 +38,11 @@
 FROM fedora:rawhide
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Install basic tools
 RUN dnf update -y \
  && dnf install -y \

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -38,6 +38,11 @@
 FROM opensuse/leap:latest
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the OS
 RUN zypper dup -y
 

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -38,6 +38,11 @@
 FROM opensuse/tumbleweed:latest
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the OS
 RUN zypper dup -y
 

--- a/utils/docker/images/Dockerfile.ubuntu-19.10
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10
@@ -38,6 +38,11 @@
 FROM ubuntu:19.10
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/utils/docker/images/Dockerfile.ubuntu-19.10_bindings
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10_bindings
@@ -39,6 +39,11 @@
 FROM ubuntu:19.10
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/utils/docker/images/Dockerfile.ubuntu-rolling
+++ b/utils/docker/images/Dockerfile.ubuntu-rolling
@@ -38,6 +38,11 @@
 FROM ubuntu:rolling
 MAINTAINER szymon.romik@intel.com
 
+# Additional parameters to build docker without building components
+ARG SKIP_VALGRIND_BUILD
+ARG SKIP_PMDK_BUILD
+ARG SKIP_LIBPMEMOBJCPP_BUILD
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -37,6 +37,11 @@
 
 set -e
 
+if [ "${SKIP_LIBPMEMOBJCPP_BUILD}" ]; then
+	echo "Variable 'SKIP_LIBPMEMOBJCPP_BUILD' is set; skipping building libpmemobj-cpp"
+	exit
+fi
+
 PACKAGE_MANAGER=$1
 
 git clone https://github.com/pmem/libpmemobj-cpp --shallow-since=2019-10-02

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -36,6 +36,11 @@
 
 set -e
 
+if [ "${SKIP_PMDK_BUILD}" ]; then
+	echo "Variable 'SKIP_PMDK_BUILD' is set; skipping building PMDK"
+	exit
+fi
+
 PACKAGE_MANAGER=$1
 
 # stable-1.7: Merge pull request #4097 from pmem/stable-1.6, 5.11.2019

--- a/utils/docker/images/install-valgrind.sh
+++ b/utils/docker/images/install-valgrind.sh
@@ -36,6 +36,11 @@
 
 set -e
 
+if [ "${SKIP_VALGRIND_BUILD}" ]; then
+	echo "Variable 'SKIP_VALGRIND_BUILD' is set; skipping building valgrind (pmem's fork)"
+	exit
+fi
+
 OS=$1
 
 git clone https://github.com/pmem/valgrind.git


### PR DESCRIPTION
Sometimes if you want to use different pmdk or valgrind you can turn them explicitly in the build and take care of them by yourself. Each additional build/install gets its own "skip" flag, which is not enabled by default.

Skips can be enabled e.g. by using command like:
```docker build --build-arg SKIP_VALGRIND_BUILD=1 --build-arg SKIP_PMDK_BUILD=on --build-arg SKIP_LIBPMEMOBJCPP_BUILD=1 ...```


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/531)
<!-- Reviewable:end -->
