### PR TITLE
Add install-libndctl.sh

### DIFF
--- a/utils/docker/images/install-libndctl.sh
+++ b/utils/docker/images/install-libndctl.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Copyright 2018-2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# install-libndctl.sh - installs libndctl
+#
+
+set -e
+
+OS=$1
+
+echo "==== clone ndctl repo ===="
+git clone https://github.com/pmem/ndctl.git
+cd ndctl
+git checkout tags/v64.1
+
+if [ "$OS" = "fedora" ]; then
+	echo "==== setup rpmbuild tree ===="
+	rpmdev-setuptree
+
+	RPMDIR=$HOME/rpmbuild/
+	VERSION=$(./git-version)
+	SPEC=./rhel/ndctl.spec
+
+	echo "==== create source tarball ====="
+	git archive --format=tar --prefix="ndctl-${VERSION}/" HEAD | gzip > "$RPMDIR/SOURCES/ndctl-${VERSION}.tar.gz"
+
+	echo "==== build ndctl ===="
+	./autogen.sh
+	./configure --disable-docs
+	make -j$(nproc)
+
+	echo "==== build ndctl packages ===="
+	rpmbuild -ba $SPEC
+
+	echo "==== install ndctl packages ===="
+	rpm -i $RPMDIR/RPMS/x86_64/*.rpm
+
+	echo "==== cleanup ===="
+	rm -rf $RPMDIR
+else
+	echo "==== set OS-specific options ===="
+	OS_SPECIFIC=""
+	LIBDIR=/usr/lib
+	case $(echo $OS | cut -d'-' -f1) in
+		centos|opensuse)
+			LIBDIR=/usr/lib64
+			;;
+		archlinux)
+			OS_SPECIFIC="--disable-dependency-tracking"
+			;;
+	esac
+
+	echo "==== build ndctl ===="
+	./autogen.sh
+	./configure --libdir=$LIBDIR --disable-docs $OS_SPECIFIC
+	make -j$(nproc)
+
+	echo "==== install ndctl ===="
+	make -j$(nproc) install
+
+	echo "==== cleanup ===="
+fi
+
+cd ..
+rm -rf ndctl


### PR DESCRIPTION
It is required to build Docker images for:
openSUSE Leap, openSUSE Tumbleweed and Arch Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/536)
<!-- Reviewable:end -->
