### PR TITLE
Add install-memkind.sh

### DIFF
--- a/utils/docker/images/install-memkind.sh
+++ b/utils/docker/images/install-memkind.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+#
+# Copyright 2019, Intel Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#
+#     * Redistributions in binary form must reproduce the above copyright
+#       notice, this list of conditions and the following disclaimer in
+#       the documentation and/or other materials provided with the
+#       distribution.
+#
+#     * Neither the name of the copyright holder nor the names of its
+#       contributors may be used to endorse or promote products derived
+#       from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#
+# install-memkind.sh <install_in_sys> -
+#	if argument is given and equals to "sys" then it installs master version in sys path
+#	otherwise it installs master and stable versions in /opt directory
+
+set -e
+
+OS=$1
+
+# v1.9.0-73-g1ece023; 25.09.2019, contains new libmemkind namespace
+MEMKIND_VERSION=1ece023b9c06a68d3f329786d1c4c0e65cef390f
+
+WORKDIR=$(pwd)
+
+git clone https://github.com/memkind/memkind
+cd $WORKDIR/memkind
+git checkout $MEMKIND_VERSION
+
+# set OS-specific configure options
+OS_SPECIFIC=""
+case $(echo $OS | cut -d'-' -f1) in
+	centos|opensuse)
+		OS_SPECIFIC="--libdir=/usr/lib64"
+		;;
+esac
+
+./autogen.sh
+./configure --prefix=/usr $OS_SPECIFIC
+make -j$(nproc)
+make -j$(nproc) install
+
+# cleanup
+cd $WORKDIR
+rm -r memkind


### PR DESCRIPTION
It is required to build Docker images for:
CentOS 8, openSUSE Leap, openSUSE Tumbleweed and Arch Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/537)
<!-- Reviewable:end -->
