### PR TITLE
Add option to install pmdk and libpmemobj-cpp from sources

### DIFF
--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -37,6 +37,8 @@
 
 set -e
 
+PACKAGE_MANAGER=$1
+
 git clone https://github.com/pmem/libpmemobj-cpp --shallow-since=2019-10-02
 cd libpmemobj-cpp
 
@@ -45,11 +47,17 @@ git checkout 1.8
 mkdir build
 cd build
 
-cmake .. -DCPACK_GENERATOR="$1" -DCMAKE_INSTALL_PREFIX=/usr
-make -j$(nproc) package
-if [ "$1" = "DEB" ]; then
+cmake .. -DCPACK_GENERATOR="$PACKAGE_MANAGER" -DCMAKE_INSTALL_PREFIX=/usr
+
+if [ "$PACKAGE_MANAGER" = "" ]; then
+	make -j$(nproc) install
+else
+	make -j$(nproc) package
+fi
+
+if [ "$PACKAGE_MANAGER" = "DEB" ]; then
       sudo dpkg -i libpmemobj++*.deb
-elif [ "$1" = "RPM" ]; then
+elif [ "$PACKAGE_MANAGER" = "RPM" ]; then
       sudo rpm -i libpmemobj++*.rpm
 fi
 

--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -36,16 +36,23 @@
 
 set -e
 
+PACKAGE_MANAGER=$1
+
 git clone https://github.com/pmem/pmdk --shallow-since=2019-09-26
 cd pmdk
 git checkout 1.7
 
-make -j$(nproc) BUILD_PACKAGE_CHECK=n $1
-if [ "$1" = "dpkg" ]; then
+if [ "$PACKAGE_MANAGER" = "" ]; then
+	make -j$(nproc) install prefix=/usr
+else
+	make -j$(nproc) BUILD_PACKAGE_CHECK=n $PACKAGE_MANAGER
+fi
+
+if [ "$PACKAGE_MANAGER" = "dpkg" ]; then
       sudo dpkg -i dpkg/libpmem_*.deb dpkg/libpmem-dev_*.deb
       sudo dpkg -i dpkg/libpmemobj_*.deb dpkg/libpmemobj-dev_*.deb
       sudo dpkg -i dpkg/pmreorder_*.deb
-elif [ "$1" = "rpm" ]; then
+elif [ "$PACKAGE_MANAGER" = "rpm" ]; then
       sudo rpm -i rpm/*/pmdk-debuginfo-*.rpm
       sudo rpm -i rpm/*/libpmem-*.rpm
       sudo rpm -i rpm/*/libpmemobj-*.rpm


### PR DESCRIPTION
Add an option to install pmdk and libpmemobj-cpp
from sources and not from built packages.
It is required to build Docker images for Arch Linux.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/538)
<!-- Reviewable:end -->
