### PR TITLE
Fix dependency error in install-pmdk.sh

### DIFF
--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -47,8 +47,7 @@ if [ "$1" = "dpkg" ]; then
       sudo dpkg -i dpkg/pmreorder_*.deb
 elif [ "$1" = "rpm" ]; then
       sudo rpm -i rpm/*/pmdk-debuginfo-*.rpm
-      sudo rpm -i rpm/*/libpmem-*.rpm
-      sudo rpm -i rpm/*/libpmemobj-*.rpm
+      sudo rpm -i rpm/*/libpmem*-*.rpm
       sudo rpm -i rpm/*/pmreorder-*.rpm
 fi
 


### PR DESCRIPTION
It fixes this error:
error: Failed dependencies:
	libpmem1 = 1.7+git33.gbfec2ca-1.suse1550 is needed by libpmem-debug-1.7+git33.gbfec2ca-1.suse1550.x86_64
	libpmem1 = 1.7+git33.gbfec2ca-1.suse1550 is needed by libpmem-devel-1.7+git33.gbfec2ca-1.suse1550.x86_64

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/539)
<!-- Reviewable:end -->
