### PR TITLE
Add option to not test packages on Travis

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -129,6 +129,7 @@ docker run --privileged=true --name=$containerName -ti \
 	--env COVERITY_SCAN_NOTIFICATION_EMAIL=$COVERITY_SCAN_NOTIFICATION_EMAIL \
 	--env TEST_BUILD=$TEST_BUILD \
 	--env DEFAULT_TEST_DIR=/dev/shm \
+	--env TEST_PACKAGES=${TEST_PACKAGES:-ON} \
 	--shm-size=4G \
 	-v $HOST_WORKDIR:$WORKDIR \
 	-v /etc/localtime:/etc/localtime \

--- a/utils/docker/run-test-building.sh
+++ b/utils/docker/run-test-building.sh
@@ -41,6 +41,7 @@ set -e
 EXAMPLE_TEST_DIR="/tmp/build_example"
 PREFIX=/usr
 TEST_DIR=${PMEMKV_TEST_DIR:-${DEFAULT_TEST_DIR}}
+TEST_PACKAGES=${TEST_PACKAGES:-ON}
 
 function sudo_password() {
 	echo $USERPASS | sudo -Sk $*
@@ -230,24 +231,27 @@ echo "--------------------------------------------------------------------------
 
 make -j$(nproc) package
 
-if [ $PACKAGE_MANAGER = "deb" ]; then
-	sudo_password dpkg -i libpmemkv*.deb
-elif [ $PACKAGE_MANAGER = "rpm" ]; then
-	sudo_password rpm -i libpmemkv*.rpm
+if [ "$TEST_PACKAGES" == "ON" ]; then
+	if [ $PACKAGE_MANAGER = "deb" ]; then
+		sudo_password dpkg -i libpmemkv*.deb
+	elif [ $PACKAGE_MANAGER = "rpm" ]; then
+		sudo_password rpm -i libpmemkv*.rpm
+	fi
+
+	# Verify installed packages
+	compile_example_standalone pmemkv_basic_c
+	run_example_standalone pmemkv_basic_c
+	compile_example_standalone pmemkv_basic_cpp
+	run_example_standalone pmemkv_basic_cpp
+
+	# Clean after installation
+	if [ $PACKAGE_MANAGER = "deb" ]; then
+		sudo_password dpkg -r libpmemkv-dev
+	elif [ $PACKAGE_MANAGER = "rpm" ]; then
+		sudo_password rpm -e --nodeps libpmemkv-devel
+	fi
 fi
 
-# Verify installed packages
-compile_example_standalone pmemkv_basic_c
-run_example_standalone pmemkv_basic_c
-compile_example_standalone pmemkv_basic_cpp
-run_example_standalone pmemkv_basic_cpp
-
-# Clean after installation
-if [ $PACKAGE_MANAGER = "deb" ]; then
-	sudo_password dpkg -r libpmemkv-dev
-elif [ $PACKAGE_MANAGER = "rpm" ]; then
-	sudo_password rpm -e --nodeps libpmemkv-devel
-fi
 rm -rf $WORKDIR/build
 
 # Trigger auto doc update on master


### PR DESCRIPTION
It is needed when there lacks required dependent packages in the OS
(for example the memkind package in the OS is too old).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/540)
<!-- Reviewable:end -->
