### PR TITLE
Compile pmemkv_test with -Wno-deprecated-declarations flag

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -205,6 +205,13 @@ endif()
 
 target_link_libraries(pmemkv_test pmemkv libgtest ${CMAKE_DL_LIBS})
 
+# XXX It should be removed when all supported distributions update gtest
+# to at least v1.9.0.20190831-1
+# and the 'INSTANTIATE_TEST_CASE_P' macro can be replaced
+# with the 'INSTANTIATE_TEST_SUITE_P' macro.
+# See https://github.com/pmem/pmemkv/issues/527 for more details.
+target_compile_options(pmemkv_test PUBLIC "-Wno-deprecated-declarations")
+
 if(BUILD_JSON_CONFIG)
 	target_link_libraries(pmemkv_test pmemkv_json_config)
 endif()


### PR DESCRIPTION
Add -Wno-deprecated-declarations flag to CXX_FLAGS
in order that compilation of pmemkv does not fail
with the newest gtest.
See https://github.com/pmem/pmemkv/issues/527 for details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/543)
<!-- Reviewable:end -->
