### PR TITLE
Do not allocate a pseudo-TTY in GitHub Actions

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -107,11 +107,13 @@ SCRIPTSDIR=$WORKDIR/utils/docker
 
 echo Building ${OS}-${OS_VER}
 
+[ ! $GITHUB_ACTIONS ] && TTY='-t' || TTY=''
+
 # Run a container with
 #  - environment variables set (--env)
 #  - host directory containing source mounted (-v)
 #  - working directory set (-w)
-docker run --privileged=true --name=$containerName -ti \
+docker run --privileged=true --name=$containerName -i $TTY \
 	$DNS_SETTING \
 	${docker_opts} \
 	$ci_env \


### PR DESCRIPTION
... because it causes the following error:
```
the input device is not a TTY
##[error]Process completed with exit code 1.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/550)
<!-- Reviewable:end -->
