### PR TITLE
Adjust centos docker for rapidjson

### DIFF
--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -49,8 +49,7 @@ RUN dnf install -y 'dnf-command(config-manager)'
 RUN dnf config-manager --set-enabled PowerTools
 
 # Install basic tools
-RUN dnf update -y \
- && dnf install -y \
+RUN dnf install -y \
 	autoconf \
 	automake \
 	clang \

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -76,11 +76,17 @@ RUN dnf install -y \
 	tbb-devel \
 	unzip \
 	wget \
-	which \
-&& dnf clean all
+	which
 
 # Install glibc-debuginfo
 RUN dnf debuginfo-install -y glibc
+
+# Use old EPEL (from Centos 7) and install missing package
+RUN dnf remove -y epel-release
+RUN wget https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm \
+	&& dnf install -y epel-release-latest-7.noarch.rpm
+RUN dnf install -y rapidjson-devel \
+	&& dnf clean all
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh


### PR DESCRIPTION
rapidjson-devel (missing) package can be installed from EPEL for CentOS 7. Thanks to that fix we can build pmemkv out of the box (with all CMake options set to default values).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/552)
<!-- Reviewable:end -->
