### PR TITLE
Prevent generation of cppformat if CHECK_CPP_STYLE is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,8 +237,6 @@ string(REPLACE ";" ", " DEB_PACKAGE_REQUIRES "${DEB_DEPENDS}")
 add_executable(check_license EXCLUDE_FROM_ALL utils/check_license/check-license.c)
 
 add_custom_target(checkers ALL)
-add_custom_target(cppstyle)
-add_custom_target(cppformat)
 add_custom_target(check-whitespace)
 add_custom_target(check-license
 	COMMAND ${CMAKE_SOURCE_DIR}/utils/check_license/check-headers.sh
@@ -267,6 +265,8 @@ if(CHECK_CPP_STYLE)
 	else()
 		message(WARNING "clang-format not found - C++ sources will not be checked (required version: ${CLANG_FORMAT_REQUIRED})")
 	endif()
+	add_custom_target(cppformat)
+	add_custom_target(cppstyle)
 endif()
 
 if(DEVELOPER_MODE)


### PR DESCRIPTION
It's little bit annoying when
"""
 make cppformat
"""
always returns success if CHECK_CPP_STYLE=OFF. IMHO this target should
not be generated at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/558)
<!-- Reviewable:end -->
