### PR TITLE
CMap engine rework

### DIFF
--- a/src/engines/cmap.cc
+++ b/src/engines/cmap.cc
@@ -108,17 +108,7 @@ status cmap::put(string_view key, string_view value)
 		       << ", value.size=" << std::to_string(value.size()));
 	check_outside_tx();
 
-	internal::cmap::map_t::accessor acc;
-	// XXX - do not create temporary string
-	bool result = container->insert(
-		acc,
-		internal::cmap::map_t::value_type(internal::cmap::string_t(key),
-						  internal::cmap::string_t(value)));
-	if (!result) {
-		pmem::obj::transaction::manual tx(pmpool);
-		acc->second = value;
-		pmem::obj::transaction::commit();
-	}
+	container->insert_or_assign(key, value);
 
 	return status::OK;
 }

--- a/src/polymorphic_string.h
+++ b/src/polymorphic_string.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Intel Corporation
+ * Copyright 2019-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,48 +47,37 @@ public:
 	using pmem_string = pmem::obj::string;
 	polymorphic_string()
 	{
-		construct();
 	}
 
-	polymorphic_string(const char *data, std::size_t size)
+	polymorphic_string(const char *data, std::size_t size) : pstr(data, size)
 	{
-		construct(data, size);
 	}
 
-	polymorphic_string(const std::string &s)
+	polymorphic_string(const std::string &s) : pstr(s)
 	{
-		construct(s);
 	}
 
-	polymorphic_string(const pmem_string &s)
+	polymorphic_string(const pmem_string &s) : pstr(s)
 	{
-		construct(s.c_str(), s.size());
 	}
 
-	polymorphic_string(string_view s)
+	polymorphic_string(string_view s) : pstr(s.data(), s.size())
 	{
-		construct(s.data(), s.size());
 	}
 
-	polymorphic_string(const polymorphic_string &s)
+	polymorphic_string(const polymorphic_string &s) : pstr(s.pstr)
 	{
-		construct(s.c_str(), s.size());
 	}
 
 	polymorphic_string &operator=(const std::string &s)
 	{
-		if (is_pmem.get_ro()) {
-			pstr = s;
-		} else {
-			str = s;
-		}
-
+		pstr = s;
 		return *this;
 	}
 
 	polymorphic_string &operator=(const pmem_string &s)
 	{
-		assert(is_pmem.get_ro());
+		check_pmem();
 		pstr = s;
 
 		return *this;
@@ -96,53 +85,34 @@ public:
 
 	polymorphic_string &operator=(const polymorphic_string &s)
 	{
-		if (s.is_pmem.get_ro()) {
-			this->operator=(s.pstr);
-		} else {
-			this->operator=(s.str);
-		}
-
+		this->operator=(s.pstr);
 		return *this;
 	}
 
 	polymorphic_string &operator=(string_view s)
 	{
-		if (is_pmem.get_ro()) {
-			pstr.assign(s.data(), s.size());
-		} else {
-			str.assign(s.data(), s.size());
-		}
-
+		pstr.assign(s.data(), s.size());
 		return *this;
-	}
-
-	~polymorphic_string()
-	{
-		if (is_pmem.get_ro()) {
-			pstr.~basic_string();
-		} else {
-			str.~basic_string();
-		}
 	}
 
 	char &operator[](size_t n)
 	{
-		return is_pmem.get_ro() ? pstr[n] : str[n];
+		return pstr[n];
 	}
 
 	const char &operator[](size_t n) const
 	{
-		return is_pmem.get_ro() ? pstr[n] : str[n];
+		return pstr[n];
 	}
 
 	const char *c_str() const
 	{
-		return is_pmem.get_ro() ? pstr.c_str() : str.c_str();
+		return pstr.c_str();
 	}
 
 	size_t size() const
 	{
-		return is_pmem.get_ro() ? pstr.size() : str.size();
+		return pstr.size();
 	}
 
 	size_t length() const
@@ -173,31 +143,17 @@ public:
 	template <typename... Args>
 	int compare(Args &&... args) const
 	{
-		return is_pmem.get_ro() ? pstr.compare(std::forward<Args>(args)...)
-					: str.compare(std::forward<Args>(args)...);
+		return pstr.compare(std::forward<Args>(args)...);
 	}
 
 private:
-	pmem::obj::p<bool> is_pmem;
-	union {
-		std::string str;
-		pmem_string pstr;
-	};
+	/* required for layout in compatibility purpose */
+	pmem::obj::p<bool> unused = true;
+	pmem_string pstr;
 
-	bool check_pmem() const
+	void check_pmem() const
 	{
-		return pmemobj_pool_by_ptr(this) != nullptr;
-	}
-
-	template <typename... Args>
-	void construct(Args &&... args)
-	{
-		is_pmem.get_rw() = check_pmem();
-		if (is_pmem.get_ro()) {
-			new (&pstr) pmem_string(std::forward<Args>(args)...);
-		} else {
-			new (&str) std::string(std::forward<Args>(args)...);
-		}
+		assert(pmemobj_pool_by_ptr(this) != nullptr);
 	}
 }; // class polymorphic_string
 


### PR DESCRIPTION
Refactoring CMap engine to use concurrent_hash_map's 'insert_or_assign' instead of 'insert'.
Changing libpmemobj-cpp and pmdk install scripts to versions needed to use insert_or_assign.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/580)
<!-- Reviewable:end -->
