### PR TITLE
Fix: do not shallow clone in install-pmdk

### DIFF
--- a/utils/docker/images/install-pmdk.sh
+++ b/utils/docker/images/install-pmdk.sh
@@ -46,7 +46,7 @@ PACKAGE_MANAGER=$1
 # devel-1.8: Merge pull request #4497 from marcinslusarz/build, 23.01.2020
 PMDK_VERSION="1947982d15ebb3d107e781cdc1484ef4ce81cc41"
 
-git clone https://github.com/pmem/pmdk --shallow-since=2019-09-26
+git clone https://github.com/pmem/pmdk
 cd pmdk
 git checkout $PMDK_VERSION
 


### PR DESCRIPTION
The shallow clone does not contain the 'devel-1.8' branch
which we want to checkout.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/582)
<!-- Reviewable:end -->
