### PR TITLE
Fix runtime_initialize() in cmap.cc

### DIFF
--- a/src/engines/cmap.cc
+++ b/src/engines/cmap.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -143,7 +143,7 @@ void cmap::Recover()
 		*root_oid = pmem::obj::make_persistent<internal::cmap::map_t>().raw();
 		pmem::obj::transaction::commit();
 		container = (pmem::kv::internal::cmap::map_t *)pmemobj_direct(*root_oid);
-		container->runtime_initialize(true);
+		container->runtime_initialize();
 	}
 }
 


### PR DESCRIPTION
It fixes the following compilation error:
```
/pmemkv/src/engines/cmap.cc: In member function 'void pmem::kv::cmap::Recover()':
/pmemkv/src/engines/cmap.cc:146:37: error: 'void pmem::obj::concurrent_hash_map<Key, T, Hash, KeyEqual, MutexType, ScopedLockType>::runtime_initialize(bool) [with Key = pmem::kv::polymorphic_string; T = pmem::kv::polymorphic_string; Hash = pmem::kv::internal::cmap::string_hasher; KeyEqual = std::equal_to<pmem::kv::polymorphic_string>; MutexType = pmem::obj::shared_mutex; ScopedLockType = pmem::obj::concurrent_hash_map_internal::shared_mutex_scoped_lock<pmem::obj::shared_mutex>]' is deprecated: runtime_initialize(bool) is now deprecated, use runtime_initialize(void) [-Werror=deprecated-declarations]
  146 |   container->runtime_initialize(true);
      |                                     ^
In file included from /pmemkv/src/engines/cmap.h:38,
                 from /pmemkv/src/engines/cmap.cc:33:
/usr/include/libpmemobj++/container/concurrent_hash_map.hpp:2212:2: note: declared here
 2212 |  runtime_initialize(bool graceful_shutdown)
      |  ^~~~~~~~~~~~~~~~~~
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/583)
<!-- Reviewable:end -->
