### PR TITLE
tests: replace raw pointer to db with std::unique_ptr

### DIFF
--- a/tests/engines/cmap_pmemobj_test.cc
+++ b/tests/engines/cmap_pmemobj_test.cc
@@ -36,6 +36,7 @@
 #include <cstdio>
 #include <libpmemobj++/persistent_ptr.hpp>
 #include <libpmemobj++/transaction.hpp>
+#include <memory>
 
 using namespace pmem::kv;
 
@@ -47,7 +48,7 @@ private:
 	std::string PATH = test_path + "/cmap_pmemobj_test";
 
 public:
-	db *kv;
+	std::unique_ptr<db> kv = nullptr;
 
 	CMapPmemobjTest()
 	{
@@ -57,14 +58,13 @@ public:
 
 	~CMapPmemobjTest()
 	{
-		delete kv;
 		pmpool.close();
 
 		std::remove(PATH.c_str());
 	}
 	void Restart()
 	{
-		delete kv;
+		kv.reset(nullptr);
 		pmpool.close();
 		Start(false);
 	}
@@ -88,7 +88,7 @@ protected:
 		if (cfg_o != status::OK)
 			throw std::runtime_error("putting 'oid' to config failed");
 
-		kv = new db;
+		kv.reset(new db);
 		auto s = kv->open("cmap", std::move(cfg));
 		if (s != status::OK)
 			throw std::runtime_error(errormsg());

--- a/tests/engines/cmap_test.cc
+++ b/tests/engines/cmap_test.cc
@@ -33,6 +33,7 @@
 #include "../../src/libpmemkv.hpp"
 #include "gtest/gtest.h"
 #include <cstdio>
+#include <memory>
 #include <string>
 #include <thread>
 #include <vector>
@@ -64,7 +65,7 @@ private:
 	std::string PATH = test_path + "/cmap_test";
 
 public:
-	db *kv;
+	std::unique_ptr<db> kv = nullptr;
 
 	CMapBaseTest()
 	{
@@ -75,13 +76,12 @@ public:
 	~CMapBaseTest()
 	{
 		kv->close();
-		delete kv;
 		std::remove(PATH.c_str());
 	}
 	void Restart()
 	{
 		kv->close();
-		delete kv;
+		kv.reset(nullptr);
 		Start(false);
 	}
 
@@ -106,7 +106,7 @@ protected:
 					"putting 'size' to config failed");
 		}
 
-		kv = new db;
+		kv.reset(new db);
 		auto s = kv->open("cmap", std::move(cfg));
 		if (s != status::OK)
 			throw std::runtime_error(errormsg());

--- a/tests/engines/vcmap_test.cc
+++ b/tests/engines/vcmap_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019, Intel Corporation
+ * Copyright 2017-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -33,6 +33,7 @@
 #include "../../src/libpmemkv.hpp"
 #include "gtest/gtest.h"
 #include <cstdio>
+#include <memory>
 #include <sys/stat.h>
 
 using namespace pmem::kv;
@@ -47,7 +48,7 @@ private:
 	std::string PATH = test_path + "/vcmap_test";
 
 public:
-	db *kv;
+	std::unique_ptr<db> kv = nullptr;
 
 	VCMapBaseTest()
 	{
@@ -64,7 +65,7 @@ public:
 		if (cfg_s != status::OK)
 			throw std::runtime_error("putting 'size' to config failed");
 
-		kv = new db;
+		kv.reset(new db);
 		auto s = kv->open("vcmap", std::move(cfg));
 		if (s != status::OK)
 			throw std::runtime_error(errormsg());
@@ -73,7 +74,6 @@ public:
 	~VCMapBaseTest()
 	{
 		kv->close();
-		delete kv;
 		std::remove(PATH.c_str());
 	}
 };

--- a/tests/engines/vsmap_test.cc
+++ b/tests/engines/vsmap_test.cc
@@ -35,6 +35,7 @@
 #include <sys/stat.h>
 
 #include <cstdio>
+#include <memory>
 
 using namespace pmem::kv;
 
@@ -48,7 +49,7 @@ private:
 	std::string PATH = test_path + "/vsmap_test";
 
 public:
-	db *kv;
+	std::unique_ptr<db> kv = nullptr;
 
 	VSMapBaseTest()
 	{
@@ -65,7 +66,7 @@ public:
 		if (cfg_s != status::OK)
 			throw std::runtime_error("putting 'size' to config failed");
 
-		kv = new db;
+		kv.reset(new db);
 		auto s = kv->open("vsmap", std::move(cfg));
 		if (s != status::OK)
 			throw std::runtime_error(errormsg());
@@ -74,7 +75,6 @@ public:
 	~VSMapBaseTest()
 	{
 		kv->close();
-		delete kv;
 		std::remove(PATH.c_str());
 	}
 };


### PR DESCRIPTION
Using raw pointer could cause memory leak if exception was thrown
in destructor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/596)
<!-- Reviewable:end -->
