### PR TITLE
tests: fix handling test dir

### DIFF
--- a/tests/pmemkv_c_api_test.cc
+++ b/tests/pmemkv_c_api_test.cc
@@ -50,6 +50,8 @@ public:
 	void SetUp()
 	{
 		path = params.get_path();
+		std::remove(path.c_str());
+
 		if (!params.use_file)
 			mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 
@@ -72,8 +74,7 @@ public:
 	void TearDown()
 	{
 		pmemkv_close(db);
-		if (params.force_create == 1)
-			std::remove(path.c_str());
+		std::remove(path.c_str());
 	}
 };
 

--- a/tests/test_suite.h
+++ b/tests/test_suite.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Intel Corporation
+ * Copyright 2019-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,9 +65,8 @@ struct Basic {
 	std::string get_path()
 	{
 		std::string abs_path(*path);
-		if (use_file) {
-			abs_path.append("/" + name);
-		}
+		abs_path.append("/" + name);
+
 		return abs_path;
 	}
 };


### PR DESCRIPTION
In case of engines which expected folder as path (vsmap/vcmap) we passed
path to a top level test dir which we later removed. Fix this by always
appending test name to a path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/599)
<!-- Reviewable:end -->
