### PR TITLE
Fix setting compilers - do not mix gcc with clang

### DIFF
--- a/utils/docker/run-test-building.sh
+++ b/utils/docker/run-test-building.sh
@@ -111,7 +111,7 @@ function run_test_check_support_cpp20_gcc() {
 	mkdir $WORKDIR/build
 	cd $WORKDIR/build
 
-	CXX=g++ cmake .. -DCMAKE_BUILD_TYPE=Release \
+	CC=gcc CXX=g++ cmake .. -DCMAKE_BUILD_TYPE=Release \
 		-DTEST_DIR=$TEST_DIR \
 		-DCMAKE_INSTALL_PREFIX=$PREFIX \
 		-DBUILD_JSON_CONFIG=${BUILD_JSON_CONFIG} \
@@ -136,7 +136,7 @@ function run_test_check_support_cpp20_clang() {
 	mkdir $WORKDIR/build
 	cd $WORKDIR/build
 
-	CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Release \
+	CC=clang CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Release \
 		-DTEST_DIR=$TEST_DIR \
 		-DCMAKE_INSTALL_PREFIX=$PREFIX \
 		-DBUILD_JSON_CONFIG=${BUILD_JSON_CONFIG} \


### PR DESCRIPTION
Do not mix gcc with clang:
-- The C compiler identification is GNU 10.0.1
-- The CXX compiler identification is Clang 9.0.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/602)
<!-- Reviewable:end -->
