### PR TITLE
Work around a missing include in memkind headers.

### DIFF
--- a/cmake/memkind.cmake
+++ b/cmake/memkind.cmake
@@ -59,7 +59,8 @@ include_directories(${MEMKIND_INCLUDE_DIRS})
 set(SAVED_CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES})
 set(CMAKE_REQUIRED_INCLUDES ${MEMKIND_INCLUDE_DIRS})
 CHECK_CXX_SOURCE_COMPILES(
-		"#include \"pmem_allocator.h\"
+		"#include <stdexcept>
+		#include \"pmem_allocator.h\"
 		int main(void) {
 		libmemkind::pmem::allocator<int> *alc = nullptr;
 		(void)alc;


### PR DESCRIPTION
First, CMake fails to find memkind_ns:
```
-- Checking for module 'memkind>=1.8.0'
--   Found memkind, version 1.10.0
-- Performing Test LIBMEMKIND_NAMESPACE_PRESENT
-- Performing Test LIBMEMKIND_NAMESPACE_PRESENT - Failed
```
then, the fallback code fails:
```
In file included from /home/kilobyte/c/pmemkv/src/engines/vsmap.cc:33:
/home/kilobyte/c/pmemkv/src/engines/vsmap.h:86:25: error: ‘allocator’ is not a member of ‘memkind_ns’
   86 |             memkind_ns::allocator<char>>;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/603)
<!-- Reviewable:end -->
