### PR TITLE
doc: add links to errors section

### DIFF
--- a/doc/libpmemkv.3.md.in
+++ b/doc/libpmemkv.3.md.in
@@ -7,7 +7,7 @@ header: PMEMKV
 secondary_title: pmemkv
 ...
 
-[comment]: <> (Copyright 2019, Intel Corporation)
+[comment]: <> (Copyright 2019-2020, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -40,6 +40,7 @@ secondary_title: pmemkv
 [SYNOPSIS](#synopsis)<br />
 [DESCRIPTION](#description)<br />
 [EXAMPLE](#example)<br />
+[ERRORS](#errors)<br />
 [SEE ALSO](#see-also)<br />
 
 

--- a/doc/libpmemkv_config.3.md.in
+++ b/doc/libpmemkv_config.3.md.in
@@ -7,7 +7,7 @@ header: PMEMKV_CONFIG
 secondary_title: pmemkv
 ...
 
-[comment]: <> (Copyright 2019, Intel Corporation)
+[comment]: <> (Copyright 2019-2020, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -40,6 +40,7 @@ secondary_title: pmemkv
 [SYNOPSIS](#synopsis)<br />
 [DESCRIPTION](#description)<br />
 [EXAMPLE](#example)<br />
+[ERRORS](#errors)<br />
 [SEE ALSO](#see-also)<br />
 
 

--- a/doc/libpmemkv_json_config.3.md
+++ b/doc/libpmemkv_json_config.3.md
@@ -7,7 +7,7 @@ header: PMEMKV_JSON_CONFIG
 secondary_title: pmemkv_json_config
 ...
 
-[comment]: <> (Copyright 2019, Intel Corporation)
+[comment]: <> (Copyright 2019-2020, Intel Corporation)
 
 [comment]: <> (Redistribution and use in source and binary forms, with or without)
 [comment]: <> (modification, are permitted provided that the following conditions)
@@ -40,6 +40,7 @@ secondary_title: pmemkv_json_config
 [SYNOPSIS](#synopsis)<br />
 [DESCRIPTION](#description)<br />
 [EXAMPLE](#example)<br />
+[ERRORS](#errors)<br />
 [SEE ALSO](#see-also)<br />
 
 


### PR DESCRIPTION
to speed up searching for errors' descriptions.

It's merely a sub-section (`##`), but I believe we should have a link on top to increase readability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/614)
<!-- Reviewable:end -->
