### PR TITLE
Make the documention build reproducibly

### DIFF
--- a/utils/md2man/md2man.sh
+++ b/utils/md2man/md2man.sh
@@ -56,6 +56,7 @@ section=`sed -n 's/^title:.*\([0-9]\))$/\1/p' $filename`
 secondary_title=`sed -n 's/^secondary_title:\ *\(.*\)$/\1/p' $filename`
 
 dt="$(date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%F)"
+year="$(date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y)"
 # since genereted docs are not kept in the repo the output dir may not exist
 out_dir=`echo $outfile | sed 's/\(.*\)\/.*/\1/'`
 mkdir -p $out_dir
@@ -64,7 +65,7 @@ cat $filename | sed -n -e '/# NAME #/,$p' |\
 	pandoc -s -t man -o $outfile --template=$template \
 	-V title=$title -V section=$section \
 	-V date="$dt" -V version="$version" \
-	-V year=$(date +"%Y") -V secondary_title="$secondary_title" |
+	-V year="$year" -V secondary_title="$secondary_title" |
 sed '/^\.IP/{
 N
 /\n\.nf/{


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that pmemkv could not be built reproducibly.

This is because, whilst it used the date in manpages from [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch) (ie. the `dt` variable), it used the current build year when templating the `year` variable.

This was originally filed in Debian as [#952990](https://bugs.debian.org/952990).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/615)
<!-- Reviewable:end -->
