### PR TITLE
docker: add hub package to proper OS

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-30
+++ b/utils/docker/images/Dockerfile.fedora-30
@@ -53,7 +53,6 @@ RUN dnf update -y \
 	git \
 	graphviz \
 	gtest-devel \
-	hub \
 	libtool \
 	make \
 	man \

--- a/utils/docker/images/Dockerfile.ubuntu-19.04
+++ b/utils/docker/images/Dockerfile.ubuntu-19.04
@@ -54,6 +54,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	fakeroot \
 	git \
 	graphviz \
+	hub \
 	libc6-dbg \
 	libdaxctl-dev \
 	libgtest-dev \


### PR DESCRIPTION
auto doc update is executed (on stable-1.0) on Ubuntu rather than on Fedora

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/618)
<!-- Reviewable:end -->
