### PR TITLE
Catch std::exception in catch_and_return_status

### DIFF
--- a/src/libpmemkv.cc
+++ b/src/libpmemkv.cc
@@ -85,6 +85,9 @@ static inline int catch_and_return_status(const char *func_name, Function &&f)
 	} catch (pmem::transaction_scope_error &e) {
 		out_err_stream(func_name) << e.what();
 		return PMEMKV_STATUS_TRANSACTION_SCOPE_ERROR;
+	} catch (std::exception &e) {
+		out_err_stream(func_name) << e.what();
+		return PMEMKV_STATUS_UNKNOWN_ERROR;
 	} catch (...) {
 		out_err_stream(func_name) << "Unspecified error";
 		return PMEMKV_STATUS_UNKNOWN_ERROR;


### PR DESCRIPTION
Ssome exceptions (like std::length_error) were catched
by catch(...) which means we were loosing error message in
that cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/624)
<!-- Reviewable:end -->
