### PR TITLE
Add missing tests/true.cmake

### DIFF
--- a/tests/true.cmake
+++ b/tests/true.cmake
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright 2020, Intel Corporation
+
+# true.cmake - cmake script which always succeeds
+
+return()


### PR DESCRIPTION
It is needed when pmemcheck is not detected for skipping tests.
Ref: https://github.com/pmem/pmemkv/issues/653

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/654)
<!-- Reviewable:end -->
