### PR TITLE
Fix typos in Docker README

### DIFF
--- a/utils/docker/images/README.md
+++ b/utils/docker/images/README.md
@@ -1,28 +1,28 @@
 # Content
 
 Dockerfiles and scripts placed in this directory are indended to be used as
-developement process vehicles and part of continuous integration process.
+development process vehicles and part of continuous integration process.
 
-Images built out of those recipes may by used with docker or podman as
-developement environment.
-Only those used on travis are fully tested on a daily basis.
+Images built out of those recipes may by used with Docker or podman as
+development environment.
+Only those used on Travis are fully tested on a daily basis.
 In case of any problem, patches and github issues are welcome.
 
 # How to build docker image
 
 ```sh
-docker build --build-arg https_proxy=https://proxy.com:port --build-arg http_proxy=http://proxy.com:port -t pmemkv:debian-unstable -f ./Dockerfile.debian-unstable .
+docker build --build-arg https_proxy=http://proxy.com:port --build-arg http_proxy=http://proxy.com:port -t pmemkv:debian-unstable -f ./Dockerfile.debian-unstable .
 ```
 
 # How to use docker image
 
-To run build and tests on local machine on docker:
+To run build and tests on local machine on Docker:
 
 ```sh
 docker run --network=bridge --shm-size=4G -v /your/workspace/path/:/opt/workspace:z -w /opt/workspace/ -e CC=clang -e CXX=clang++ -e PKG_CONFIG_PATH=/opt/pmdk/lib/pkgconfig -it pmemkv:debian-unstable /bin/bash
 ```
 
-To get strace working, add to docker commandline
+To get strace working, add to Docker commandline
 
 ```sh
  --cap-add SYS_PTRACE


### PR DESCRIPTION
Correct of:
- Minor typos in whole file
- Cloning Valgrind repository produces: gnutls_handshake() failed: The TLS connection was non-properly terminated

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/657)
<!-- Reviewable:end -->
