### PR TITLE
Fix GHA checkout & commit range variable

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v2
+         with:
+            fetch-depth: 50
 
        - name: Pull or rebuild the image
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh

--- a/utils/docker/set-ci-vars.sh
+++ b/utils/docker/set-ci-vars.sh
@@ -41,10 +41,26 @@ function get_commit_range_from_last_merge {
 	# get commit id of the last merge
 	LAST_MERGE=$(git log --merges --pretty=%H -1)
 	LAST_COMMIT=$(git log --pretty=%H -1)
-	if [ "$LAST_MERGE" == "$LAST_COMMIT" ]; then
+	RANGE_END="HEAD"
+	if [ -n "$GITHUB_ACTIONS" ] && [ "$GITHUB_EVENT_NAME" == "pull_request" ] && [ "$LAST_MERGE" == "$LAST_COMMIT" ]; then
 		# GitHub Actions commits its own merge in case of pull requests
 		# so the first merge commit has to be skipped.
+
+		LAST_COMMIT=$(git log --pretty=%H -2 | tail -n1)
 		LAST_MERGE=$(git log --merges --pretty=%H -2 | tail -n1)
+		# If still the last commit is a merge commit it means we're manually
+		# merging changes (probably back from stable branch). We have to use
+		# left parent of the merge and the current commit for COMMIT_RANGE.
+		if [ "$LAST_MERGE" == "$LAST_COMMIT" ]; then
+			LAST_MERGE=$(git log --merges --pretty=%P -2 | tail -n1 | cut -d" " -f1)
+			RANGE_END=$LAST_COMMIT
+		fi
+	elif [ "$LAST_MERGE" == "$LAST_COMMIT" ] &&
+		([ "$TRAVIS_EVENT_TYPE" == "push" ] || [ "$GITHUB_EVENT_NAME" == "push" ]); then
+		# Other case in which last commit equals last merge, is when commiting
+		# a manual merge. Push events don't set proper COMMIT_RANGE.
+		# It has to be then set: from merge's left parent to the current commit.
+		LAST_MERGE=$(git log --merges --pretty=%P -1 | cut -d" " -f1)
 	fi
 	if [ "$LAST_MERGE" == "" ]; then
 		# possible in case of shallow clones
@@ -52,7 +68,7 @@ function get_commit_range_from_last_merge {
 		# - pick up the first commit
 		LAST_MERGE=$(git log --pretty=%H | tail -n1)
 	fi
-	COMMIT_RANGE="$LAST_MERGE..HEAD"
+	COMMIT_RANGE="$LAST_MERGE..$RANGE_END"
 	# make sure it works now
 	if ! git rev-list $COMMIT_RANGE >/dev/null; then
 		COMMIT_RANGE=""


### PR DESCRIPTION
I've missed the checkout param, which is important for checking the commit range (and decision if rebuild the image). Along with this change, the COMMIT_RANGE was fixed for branches with manual merges.

It's needed i.a. for https://github.com/pmem/pmemkv/pull/647 to work. Tested on my fork: https://github.com/lukaszstolarczuk/pmemkv/pull/1 (on both - push and pull_request events, on Travis and GHA).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/661)
<!-- Reviewable:end -->
