### PR TITLE
add issue templates for GitHub interface

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,57 @@
+---
+name: Bug report
+about: Did you find a bug in pmemkv? Please let us know.
+labels: "Type: Bug"
+---
+<!--
+Before creating new issue, ensure that similar issue wasn't already created
+  * Search: https://github.com/pmem/pmemkv/issues
+
+Note that if you do not provide enough information to reproduce the issue, we may not be able to take action on your report.
+Remember this is just a minimal template. You can extend it with data you think may be useful.
+-->
+
+# ISSUE: <!-- fill the title of issue -->
+
+## Environment Information
+
+- pmemkv version(s):                                                 <!-- fill this out -->
+- libpmemobj-cpp version(s):                                         <!-- fill this out -->
+- PMDK (libpmem/libpmemobj) package version(s):                      <!-- fill this out -->
+- OS(es) version(s):                                                 <!-- fill this out -->
+- kernel version(s):                                                 <!-- fill this out -->
+- compiler, libraries, packaging and other related tools version(s): <!-- fill this out -->
+
+and possibly:
+- TBB version(s):                                                    <!-- fill this out -->
+- memkind version(s):                                                <!-- fill this out -->
+- ndctl version(s):                                                  <!-- fill this out -->
+<!-- fill in also other useful environment data -->
+
+## Please provide a reproduction of the bug:
+
+<!-- fill this out -->
+
+## How often bug is revealed:
+
+(always, often, rare) <!-- pick one if possible -->
+<!-- describe special circumstances -->
+
+## Actual behavior:
+
+<!-- fill this out -->
+
+## Expected behavior:
+
+<!-- fill this out -->
+
+## Details
+
+<!-- fill this out -->
+
+## Additional information about Priority and Help Requested:
+
+Are you willing to submit a pull request with a proposed change? (Yes, No)  <!-- check one if possible -->
+
+Requested priority: (Showstopper, High, Medium, Low)                        <!-- check one if possible -->
+

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,26 @@
+---
+name: Feature
+about: Feature your request
+labels: "Type: Feature"
+---
+# FEAT: <!-- fill the title of feature -->
+
+## Rationale
+
+<!-- fill this out -->
+
+## Description
+
+<!-- fill this out -->
+
+## API Changes
+
+<!-- fill this out -->
+
+## Implementation details
+
+<!-- fill this out if possible -->
+
+## Meta
+
+<!-- fill this out -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,15 @@
+---
+name: Question
+about: Do you have question regarding pmemkv? Don't hesitate to ask.
+labels: "Type: Question"
+---
+# QUESTION: <!-- fill the title of question -->
+
+## Details
+
+<!-- fill this out -->
+
+<!--
+For questions and other non-bugs, you could use http://groups.google.com/group/pmem
+You could also chat with members of the PMDK/pmemkv team real-time on the #pmem IRC channel on OFTC
+-->


### PR DESCRIPTION
if we merge it, it has to be enabled in Settings section, I believe

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/674)
<!-- Reviewable:end -->
