### PR TITLE
open: always delete config in case of open failure

### DIFF
--- a/doc/libpmemkv.3.md.in
+++ b/doc/libpmemkv.3.md.in
@@ -82,7 +82,7 @@ If an engine does not support a certain function, it will return PMEMKV\_STATUS\
 	The `engine` parameter specifies the engine name (see **libpmemkv**(7) for the list of available engines).
 	The `config` parameter specifies configuration (see **libpmemkv_config**(3) for details). Pmemkv takes
 	ownership of the config parameter - this means that pmemkv_config_delete() must NOT be called
-	after successful open.
+	after open (successful or failed).
 
 `void pmemkv_close(pmemkv_db *kv);`
 

--- a/src/libpmemkv.cc
+++ b/src/libpmemkv.cc
@@ -211,13 +211,12 @@ int pmemkv_config_get_string(pmemkv_config *config, const char *key, const char 
 
 int pmemkv_open(const char *engine_c_str, pmemkv_config *config, pmemkv_db **db)
 {
+	std::unique_ptr<pmem::kv::internal::config> cfg(config_to_internal(config));
+
 	if (!db)
 		return PMEMKV_STATUS_INVALID_ARGUMENT;
 
 	return catch_and_return_status(__func__, [&] {
-		std::unique_ptr<pmem::kv::internal::config> cfg(
-			config_to_internal(config));
-
 		auto engine = pmem::kv::engine_base::create_engine(engine_c_str,
 								   std::move(cfg));
 

--- a/tests/c_api/null_db_config.c
+++ b/tests/c_api/null_db_config.c
@@ -67,6 +67,17 @@ void null_config_test(const char *engine)
 	UT_ASSERT(s == PMEMKV_STATUS_INVALID_ARGUMENT);
 }
 
+void null_db_test(const char *engine)
+{
+	pmemkv_config *cfg = pmemkv_config_new();
+	UT_ASSERTne(cfg, NULL);
+
+	int s = pmemkv_open(engine, cfg, NULL);
+	UT_ASSERTeq(s, PMEMKV_STATUS_INVALID_ARGUMENT);
+
+	/* Config should be deleted by pmemkv */
+}
+
 int main(int argc, char *argv[])
 {
 	START();
@@ -76,6 +87,7 @@ int main(int argc, char *argv[])
 
 	check_null_db_test();
 	null_config_test(argv[1]);
+	null_db_test(argv[1]);
 
 	return 0;
 }


### PR DESCRIPTION
Until now, config was not deleted if nullptr was passed to
pmemkv_open. This was inconsistent with behavior on any other failure.

The documentation was also not entirely true.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/677)
<!-- Reviewable:end -->
