### PR TITLE
tests: report error if binary is not built

### DIFF
--- a/tests/ctest_helpers.cmake
+++ b/tests/ctest_helpers.cmake
@@ -208,8 +208,7 @@ function(add_test_common executable test_name tracer testcase cmake_script)
 
 	# if test was not build
 	if (NOT TARGET ${executable})
-		message(WARNING "${executable} not build. Skipping.")
-		return()
+		message(FATAL_ERROR "${executable} not build. Skipping.")
 	endif()
 
 	# skip all valgrind tests on windows


### PR DESCRIPTION
We do not need to handle case where binary is not built, it's
always an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/682)
<!-- Reviewable:end -->
