### PR TITLE
update run-coverity.sh script

### DIFF
--- a/utils/docker/run-coverity.sh
+++ b/utils/docker/run-coverity.sh
@@ -8,10 +8,32 @@
 
 set -e
 
-./prepare-for-build.sh
+if [[ "$CI_REPO_SLUG" != "$GITHUB_REPO" \
+   && ( "$COVERITY_SCAN_NOTIFICATION_EMAIL" == "" \
+     || "$COVERITY_SCAN_TOKEN" == "" ) ]]; then
+	echo
+	echo "Skipping Coverity build:"\
+		"COVERITY_SCAN_TOKEN=\"$COVERITY_SCAN_TOKEN\" or"\
+		"COVERITY_SCAN_NOTIFICATION_EMAIL="\
+		"\"$COVERITY_SCAN_NOTIFICATION_EMAIL\" is not set"
+	exit 0
+fi
+
+# Prepare build environment
+source `dirname $0`/prepare-for-build.sh
+
+CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+TEMP_CF=$(mktemp)
+cp $CERT_FILE $TEMP_CF
+
+# Download Coverity certificate
+echo -n | openssl s_client -connect scan.coverity.com:443 | \
+	sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | \
+	tee -a $TEMP_CF
+
+sudo_password mv $TEMP_CF $CERT_FILE
 
 cd $WORKDIR
-
 mkdir build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Debug
@@ -20,9 +42,19 @@ export COVERITY_SCAN_PROJECT_NAME="$CI_REPO_SLUG"
 [[ "$CI_EVENT_TYPE" == "cron" ]] \
 	&& export COVERITY_SCAN_BRANCH_PATTERN="master" \
 	|| export COVERITY_SCAN_BRANCH_PATTERN="coverity_scan"
-export COVERITY_SCAN_BUILD_COMMAND="make"
+export COVERITY_SCAN_BUILD_COMMAND="make -j$(nproc)"
 
+#
 # Run the Coverity scan
+#
+
+# The 'travisci_build_coverity_scan.sh' script requires the following
+# environment variables to be set:
+# - TRAVIS_BRANCH - has to contain the name of the current branch
+# - TRAVIS_PULL_REQUEST - has to be set to 'true' in case of pull requests
+#
+export TRAVIS_BRANCH=${CI_BRANCH}
+[ "${CI_EVENT_TYPE}" == "pull_request" ] && export TRAVIS_PULL_REQUEST="true"
 
 # XXX: Patch the Coverity script.
 # Recently, this script regularly exits with an error, even though


### PR DESCRIPTION
based on PMDK's commit 96db274c7, added:
- '-j' param to Coverity command (make)
- necessary vars for Coverity script (used for Travis CI)
- Coverity certificate download
- skip for forked repos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/685)
<!-- Reviewable:end -->
