### PR TITLE
WA for Ubuntu 19.04 to work properly, since it's EOL

### DIFF
--- a/utils/docker/images/Dockerfile.ubuntu-19.04
+++ b/utils/docker/images/Dockerfile.ubuntu-19.04
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -38,8 +38,12 @@
 FROM ubuntu:19.04
 MAINTAINER lukasz.stolarczuk@intel.com
 
+# Ubuntu 19.04 is EOL
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	autoconf \
 	automake \

--- a/utils/docker/images/Dockerfile.ubuntu-19.04_bindings
+++ b/utils/docker/images/Dockerfile.ubuntu-19.04_bindings
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -39,8 +39,12 @@
 FROM ubuntu:19.04
 MAINTAINER lukasz.stolarczuk@intel.com
 
+# Ubuntu 19.04 is EOL
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	autoconf \
 	automake \


### PR DESCRIPTION
for stable-1.0 we don't want to update docker images, so if we want to keep testing it, we need a workaround for Ubuntu 19.04 (which is EOL now) - hence, change sources.list to use old-releases.

Based on: https://bugs.launchpad.net/cloud-images/+bug/1877600/comments/1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/692)
<!-- Reviewable:end -->
