### PR TITLE
Increase coverage threshold to 0.2

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,9 @@
 coverage:
+  status:
+    project:
+      default:
+        threshold: 0.2
+
   ignore:
     - doc/
     - examples/


### PR DESCRIPTION
A lot of PR add codepaths which are not testable right now
(for example error handling for malloc failure).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/695)
<!-- Reviewable:end -->
