### PR TITLE
clang-format should be required if check_style is on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ if(CHECK_CPP_STYLE)
 			message(FATAL_ERROR "required clang-format version is ${CLANG_FORMAT_REQUIRED} (version ${CLANG_FORMAT_VERSION} is installed)")
 		endif()
 	else()
-		message(WARNING "clang-format not found - C++ sources will not be checked (required version: ${CLANG_FORMAT_REQUIRED})")
+		message(FATAL_ERROR "CHECK_CPP_STYLE=ON, but clang-format not found (required version: ${CLANG_FORMAT_REQUIRED})")
 	endif()
 endif()
 


### PR DESCRIPTION
IMHO, if we set CHECK_CPP_STYLE=ON then clang-format should be required, not skipped if not found

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/697)
<!-- Reviewable:end -->
