### PR TITLE
Cleanups and updates in CMake, CI scripts and md files

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -1,7 +1,8 @@
 #
 # The 'XXX_DISABLE_' suffix is used twice in this file to disable two actions:
-# 1) XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} - disables pushing the rebuilt Docker image and
-# 2) XXX_DISABLE_AUTO_DOC_UPDATE - disables making pull requests with the update of documentation.
+# 1) XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} - disables pushing the rebuilt Docker image,
+# 2) XXX_DISABLE_AUTO_DOC_UPDATE - disables making pull requests with the update of documentation,
+# 3) XXX_COVERAGE - disables uploads of coverage reports.
 # Those two actions are disabled, because they conflict with the same ones run on Travis.
 # Only one CI (Travis or GitHub Actions) can run them at the time, so they can be enabled here,
 # when we decide to switch from Travis to GitHub Actions. The 'XXX_DISABLE_' suffix should be removed then.
@@ -26,15 +27,16 @@ jobs:
       WORKDIR:        utils/docker
     strategy:
       matrix:
-        CONFIG: ["TYPE=normal OS=fedora OS_VER=31",
-                 "TYPE=normal OS=ubuntu OS_VER=19.10",
-                 "TYPE=normal OS=ubuntu OS_VER=19.10 COVERAGE=1",
+        CONFIG: ["TYPE=debug OS=fedora OS_VER=31",
+                 "TYPE=debug OS=ubuntu OS_VER=19.10 XXX_COVERAGE=1",
+                 "TYPE=release OS=fedora OS_VER=31",
+                 "TYPE=release OS=ubuntu OS_VER=19.10",
                  "TYPE=valgrind OS=ubuntu OS_VER=19.10",
                  "TYPE=memcheck_drd OS=ubuntu OS_VER=19.10",
-                 "TYPE=building OS=fedora OS_VER=31 COVERAGE=1 PUSH_IMAGE=1 XXX_DISABLE_AUTO_DOC_UPDATE=1",
-                 "TYPE=building OS=ubuntu OS_VER=19.10 COVERAGE=1 PUSH_IMAGE=1",
-                 "TYPE=bindings OS=ubuntu OS_VER=19.10_bindings PUSH_IMAGE=1",
+                 "TYPE=building OS=fedora OS_VER=31 PUSH_IMAGE=1 XXX_DISABLE_AUTO_DOC_UPDATE=1",
+                 "TYPE=building OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1 XXX_COVERAGE=1",
                  "TYPE=compatibility OS=fedora OS_VER=31",
+                 "TYPE=bindings OS=ubuntu OS_VER=19.10_bindings PUSH_IMAGE=1",
                  "TYPE=coverity OS=ubuntu OS_VER=19.10"]
     steps:
        - name: Clone the git repo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,19 +7,7 @@ project(pmemkv)
 include(cmake/helpers.cmake)
 set_version(VERSION)
 
-# set the default build type
-if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
-	set(DEFAULT_BUILD_TYPE "Debug")
-else()
-	set(DEFAULT_BUILD_TYPE "RelWithDebInfo")
-endif()
-
-if(NOT CMAKE_BUILD_TYPE)
-	message(STATUS "Setting build type to the default one (${DEFAULT_BUILD_TYPE})")
-	set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}"
-		CACHE STRING "Choose a type of build (Debug, Release or RelWithDebInfo)" FORCE)
-endif()
-
+## CMake build options
 option(BUILD_DOC "build documentation" ON)
 option(BUILD_EXAMPLES "build examples" ON)
 option(BUILD_TESTS "build tests" ON)
@@ -30,11 +18,10 @@ option(TESTS_USE_FORCED_PMEM "run tests with PMEM_IS_PMEM_FORCE=1" OFF)
 option(TESTS_USE_VALGRIND "enable tests with valgrind (if found)" ON)
 option(TESTS_PMEMOBJ_DRD_HELGRIND "enable test of pmemobj engines under drd and helgrind (they should only be run on PMEM)")
 option(TESTS_JSON "enable tests which require libpmemkv_json_config library (BUILD_JSON_CONFIG have to be ON)" ON)
-
 option(COVERAGE "run coverage test" OFF)
-if(COVERAGE)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage")
-endif()
+
+option(DEVELOPER_MODE "enable developer's checks" OFF)
+option(CHECK_CPP_STYLE "check code style of C++ sources" OFF)
 
 # Each engine can be enabled separately.
 # By default all experimental engines are turned off.
@@ -46,55 +33,39 @@ option(ENGINE_CACHING "enable experimental caching engine" OFF)
 option(ENGINE_STREE "enable experimental stree engine" OFF)
 option(ENGINE_TREE3 "enable experimental tree3 engine" OFF)
 
-option(DEVELOPER_MODE "enable developer's checks" OFF)
-option(CHECK_CPP_STYLE "check code style of C++ sources" OFF)
+## Set required and useful variables
+set(CXX_STANDARD 11 CACHE STRING "C++ language standard")
+
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
+
+# Set the default build type
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+	set(DEFAULT_BUILD_TYPE "Debug")
+else()
+	set(DEFAULT_BUILD_TYPE "RelWithDebInfo")
+endif()
+if(NOT CMAKE_BUILD_TYPE)
+	message(STATUS "Setting build type to the default one (${DEFAULT_BUILD_TYPE})")
+	set(CMAKE_BUILD_TYPE "${DEFAULT_BUILD_TYPE}"
+		CACHE STRING "Choose a type of build (Debug, Release or RelWithDebInfo)" FORCE)
+endif()
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
+set(LIBPMEMOBJ_CPP_REQUIRED_VERSION 1.10)
+set(LIBPMEMOBJ_REQUIRED_VERSION 1.8)
+set(LIBPMEM_REQUIRED_VERSION 1.7)
+set(MEMKIND_REQUIRED_VERSION 1.8.0)
+
+set(PKG_CONFIG_REQUIRES)
+set(DEB_DEPENDS)
+set(RPM_DEPENDS)
+
+set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/test CACHE STRING "working directory for tests")
 
 # Do not treat include directories from the interfaces
 # of consumed Imported Targets as SYSTEM by default.
 set(CMAKE_NO_SYSTEM_FROM_IMPORTED 1)
-
-if(ENGINE_CMAP)
-	add_definitions(-DENGINE_CMAP)
-	message(STATUS "CMAP engine is ON")
-else()
-	message(STATUS "CMAP engine is OFF")
-endif()
-if(ENGINE_CSMAP)
-	add_definitions(-DENGINE_CSMAP)
-	message(STATUS "CSMAP engine is ON")
-else()
-	message(STATUS "CSMAP engine is OFF")
-endif()
-if(ENGINE_VCMAP)
-	add_definitions(-DENGINE_VCMAP)
-	message(STATUS "VCMAP engine is ON")
-else()
-	message(STATUS "VCMAP engine is OFF")
-endif()
-if(ENGINE_VSMAP)
-	add_definitions(-DENGINE_VSMAP)
-	message(STATUS "VSMAP engine is ON")
-else()
-	message(STATUS "VSMAP engine is OFF")
-endif()
-if(ENGINE_CACHING)
-	add_definitions(-DENGINE_CACHING)
-	message(STATUS "CACHING engine is ON")
-else()
-	message(STATUS "CACHING engine is OFF")
-endif()
-if(ENGINE_STREE)
-	add_definitions(-DENGINE_STREE)
-	message(STATUS "STREE engine is ON")
-else()
-	message(STATUS "STREE engine is OFF")
-endif()
-if(ENGINE_TREE3)
-	add_definitions(-DENGINE_TREE3)
-	message(STATUS "TREE3 engine is ON")
-else()
-	message(STATUS "TREE3 engine is OFF")
-endif()
 
 set(SOURCE_FILES
 	src/libpmemkv.cc
@@ -151,20 +122,60 @@ if(ENGINE_TREE3)
 	)
 endif()
 
+## Setup defines and check status of each engine
+if(ENGINE_CMAP)
+	add_definitions(-DENGINE_CMAP)
+	message(STATUS "CMAP engine is ON")
+else()
+	message(STATUS "CMAP engine is OFF")
+endif()
+if(ENGINE_CSMAP)
+	add_definitions(-DENGINE_CSMAP)
+	message(STATUS "CSMAP engine is ON")
 
-set(CXX_STANDARD 11 CACHE STRING "C++ language standard")
+	if(CXX_STANDARD LESS 14)
+		message(FATAL_ERROR "CXX_STANDARD must be >= 14 if ENGINE_CSMAP is ON")
+	endif()
+else()
+	message(STATUS "CSMAP engine is OFF")
+endif()
+if(ENGINE_VCMAP)
+	add_definitions(-DENGINE_VCMAP)
+	message(STATUS "VCMAP engine is ON")
+else()
+	message(STATUS "VCMAP engine is OFF")
+endif()
+if(ENGINE_VSMAP)
+	add_definitions(-DENGINE_VSMAP)
+	message(STATUS "VSMAP engine is ON")
+else()
+	message(STATUS "VSMAP engine is OFF")
+endif()
+if(ENGINE_CACHING)
+	add_definitions(-DENGINE_CACHING)
+	message(STATUS "CACHING engine is ON")
+else()
+	message(STATUS "CACHING engine is OFF")
+endif()
+if(ENGINE_STREE)
+	add_definitions(-DENGINE_STREE)
+	message(STATUS "STREE engine is ON")
+else()
+	message(STATUS "STREE engine is OFF")
+endif()
+if(ENGINE_TREE3)
+	add_definitions(-DENGINE_TREE3)
+	message(STATUS "TREE3 engine is ON")
+else()
+	message(STATUS "TREE3 engine is OFF")
+endif()
 
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
-
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
-set(LIBPMEMOBJ_CPP_REQUIRED_VERSION 1.10)
-set(LIBPMEMOBJ_REQUIRED_VERSION 1.8)
-set(LIBPMEM_REQUIRED_VERSION 1.7)
-set(MEMKIND_REQUIRED_VERSION 1.8.0)
-
+## Set compiler's flags
 if(DEVELOPER_MODE)
 	add_common_flag(-Werror)
+endif()
+if(COVERAGE)
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage")
 endif()
 
 add_common_flag(-Wall)
@@ -181,20 +192,13 @@ add_common_flag(-DDEBUG DEBUG)
 
 add_common_flag("-U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2" RELEASE)
 
+## Setup environment, find packages, configure list of package dependencies
 find_package(PkgConfig QUIET)
 include(FindPerl)
 include(ExternalProject)
 include(FindThreads)
 include(CheckCXXSourceCompiles)
 include(GNUInstallDirs)
-
-set(PKG_CONFIG_REQUIRES)
-set(DEB_DEPENDS)
-set(RPM_DEPENDS)
-
-if(ENGINE_CSMAP AND CXX_STANDARD LESS 14)
-	message(FATAL_ERROR "CXX_STANDARD must be >= 14 if ENGINE_CSMAP is set")
-endif()
 
 if(ENGINE_VSMAP OR ENGINE_VCMAP OR ENGINE_CMAP OR ENGINE_CSMAP OR ENGINE_STREE OR ENGINE_TREE3)
 	include(libpmemobj++)
@@ -229,60 +233,15 @@ string(REPLACE ";" " " PKG_CONFIG_REQUIRES "${PKG_CONFIG_REQUIRES}")
 string(REPLACE ";" ", " RPM_PACKAGE_REQUIRES "${RPM_DEPENDS}")
 string(REPLACE ";" ", " DEB_PACKAGE_REQUIRES "${DEB_DEPENDS}")
 
-add_custom_target(checkers ALL)
-add_custom_target(cppstyle)
-add_custom_target(cppformat)
-add_custom_target(check-whitespace)
-add_custom_target(check-license
-	COMMAND ${CMAKE_SOURCE_DIR}/utils/check_license/check-headers.sh
-		${CMAKE_SOURCE_DIR}
-		BSD-3-Clause)
-
-add_custom_target(check-whitespace-main
-		COMMAND ${PERL_EXECUTABLE}
-			${CMAKE_SOURCE_DIR}/utils/check_whitespace
-			${CMAKE_SOURCE_DIR}/utils/check_license/*.sh
-			${CMAKE_SOURCE_DIR}/*.md)
-
-add_dependencies(check-whitespace check-whitespace-main)
-
-if(CHECK_CPP_STYLE)
-	find_program(CLANG_FORMAT NAMES clang-format clang-format-9 clang-format-9.0)
-	set(CLANG_FORMAT_REQUIRED "9.0")
-	if(CLANG_FORMAT)
-		get_program_version_major_minor(${CLANG_FORMAT} CLANG_FORMAT_VERSION)
-		if(NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
-			message(FATAL_ERROR "required clang-format version is ${CLANG_FORMAT_REQUIRED} (version ${CLANG_FORMAT_VERSION} is installed)")
-		endif()
-	else()
-		message(FATAL_ERROR "CHECK_CPP_STYLE=ON, but clang-format not found (required version: ${CLANG_FORMAT_REQUIRED})")
-	endif()
-endif()
-
-if(DEVELOPER_MODE)
-	if(NOT PERL_FOUND)
-		message(FATAL_ERROR "Perl not found")
-	endif()
-	if(PERL_VERSION_STRING VERSION_LESS 5.16)
-		message(FATAL_ERROR "Minimum required version of Perl is 5.16)")
-	endif()
-
-	execute_process(COMMAND ${PERL_EXECUTABLE} -MText::Diff -e ""
-			ERROR_QUIET
-			RESULT_VARIABLE PERL_TEXT_DIFF_STATUS)
-	if(PERL_TEXT_DIFF_STATUS)
-		message(FATAL_ERROR "Text::Diff Perl module not found (install libtext-diff-perl or perl-Text-Diff)")
-	endif()
-
-	add_dependencies(checkers cppstyle)
-	add_dependencies(checkers check-whitespace)
-	add_dependencies(checkers check-license)
-endif()
-
+## Link libraries, setup targets
 add_library(pmemkv SHARED ${SOURCE_FILES})
 set_target_properties(pmemkv PROPERTIES SOVERSION 1)
 target_link_libraries(pmemkv PRIVATE
 	-Wl,--version-script=${CMAKE_SOURCE_DIR}/src/libpmemkv.map)
+
+target_include_directories(pmemkv PRIVATE src/valgrind)
+# Enable libpmemobj-cpp valgrind annotations
+target_compile_options(pmemkv PRIVATE -DLIBPMEMOBJ_CPP_VG_ENABLED=1)
 
 if(ENGINE_VSMAP OR ENGINE_VCMAP OR ENGINE_CMAP OR ENGINE_CSMAP OR ENGINE_STREE OR ENGINE_TREE3)
 	target_link_libraries(pmemkv PRIVATE ${LIBPMEMOBJ++_LIBRARIES})
@@ -298,6 +257,99 @@ if(ENGINE_CACHING)
 	target_link_libraries(pmemkv PRIVATE acl_cpp protocol acl)
 endif()
 
+## Configure make install/uninstall and packages
+configure_file(libpmemkv.pc.in libpmemkv.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/libpmemkv.pc
+	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+set_target_properties(pmemkv PROPERTIES PUBLIC_HEADER "src/libpmemkv.h;src/libpmemkv.hpp")
+
+install(TARGETS pmemkv
+		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+configure_file(
+	"${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+	"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+	IMMEDIATE @ONLY)
+
+add_custom_target(uninstall
+	COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
+if(NOT "${CPACK_GENERATOR}" STREQUAL "")
+	include(${CMAKE_SOURCE_DIR}/cmake/packages.cmake)
+endif()
+
+## Setup additional targets
+add_custom_target(checkers ALL)
+add_custom_target(cppstyle)
+add_custom_target(cppformat)
+add_custom_target(check-whitespace)
+add_custom_target(check-license
+	COMMAND ${CMAKE_SOURCE_DIR}/utils/check_license/check-headers.sh
+		${CMAKE_SOURCE_DIR}
+		BSD-3-Clause)
+
+if(CHECK_CPP_STYLE)
+	# check for required programs for code style check and add dependency to ALL
+	find_program(CLANG_FORMAT NAMES clang-format clang-format-9 clang-format-9.0)
+	set(CLANG_FORMAT_REQUIRED "9.0")
+	if(CLANG_FORMAT)
+		get_program_version_major_minor(${CLANG_FORMAT} CLANG_FORMAT_VERSION)
+		if(NOT (CLANG_FORMAT_VERSION VERSION_EQUAL CLANG_FORMAT_REQUIRED))
+			message(FATAL_ERROR "required clang-format version is ${CLANG_FORMAT_REQUIRED} (version ${CLANG_FORMAT_VERSION} is installed)")
+		endif()
+	else()
+		message(FATAL_ERROR "CHECK_CPP_STYLE=ON, but clang-format not found (required version: ${CLANG_FORMAT_REQUIRED})")
+	endif()
+
+	add_dependencies(checkers cppstyle)
+endif()
+
+if(DEVELOPER_MODE)
+	# check for required programs for whitespace and license checks and add dependencies to ALL
+	if(NOT PERL_FOUND)
+		message(FATAL_ERROR "Perl not found")
+	endif()
+	if(PERL_VERSION_STRING VERSION_LESS 5.16)
+		message(FATAL_ERROR "Minimum required version of Perl is 5.16)")
+	endif()
+
+	execute_process(COMMAND ${PERL_EXECUTABLE} -MText::Diff -e ""
+			ERROR_QUIET
+			RESULT_VARIABLE PERL_TEXT_DIFF_STATUS)
+	if(PERL_TEXT_DIFF_STATUS)
+		message(FATAL_ERROR "Text::Diff Perl module not found (install libtext-diff-perl or perl-Text-Diff)")
+	endif()
+
+	add_dependencies(checkers check-whitespace)
+	add_dependencies(checkers check-license)
+endif()
+
+add_cppstyle(src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/comparator/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.c*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.c*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/stree/*.h*)
+
+add_check_whitespace(main ${CMAKE_SOURCE_DIR}/utils/check_whitespace
+			${CMAKE_SOURCE_DIR}/utils/check_license/*.sh
+			${CMAKE_SOURCE_DIR}/*.md)
+
+add_check_whitespace(src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/comparator/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.c*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.c*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.h*
+		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/stree/*.h*)
+
+## Add sub-directories if builds enabled
 if(BUILD_JSON_CONFIG)
 	include(rapidjson)
 	add_definitions(-DBUILD_JSON_CONFIG)
@@ -327,16 +379,9 @@ if(BUILD_JSON_CONFIG)
 		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif()
 
-target_include_directories(pmemkv PRIVATE src/valgrind)
-# Enable libpmemobj-cpp valgrind annotations
-target_compile_options(pmemkv PRIVATE -DLIBPMEMOBJ_CPP_VG_ENABLED=1)
-
 if(BUILD_EXAMPLES)
 	add_subdirectory(examples)
 endif()
-
-set(TEST_DIR ${CMAKE_CURRENT_BINARY_DIR}/test
-	CACHE STRING "working directory for tests")
 
 if(BUILD_TESTS)
 	if(PKG_CONFIG_FOUND)
@@ -365,47 +410,6 @@ if(BUILD_TESTS)
 	add_subdirectory(tests)
 endif()
 
-configure_file(libpmemkv.pc.in libpmemkv.pc @ONLY)
-install(FILES ${CMAKE_BINARY_DIR}/libpmemkv.pc
-	DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-
-set_target_properties(pmemkv PROPERTIES PUBLIC_HEADER "src/libpmemkv.h;src/libpmemkv.hpp")
-
 if(BUILD_DOC)
 	add_subdirectory(doc)
-endif()
-
-install(TARGETS pmemkv
-		PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-		LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-		RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-configure_file(
-	"${CMAKE_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-	"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
-	IMMEDIATE @ONLY)
-
-add_custom_target(uninstall
-	COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-
-add_cppstyle(src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/comparator/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.c*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.c*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/stree/*.h*)
-
-add_check_whitespace(src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/comparator/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.c*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.c*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/*.h*
-		${CMAKE_CURRENT_SOURCE_DIR}/src/engines-experimental/stree/*.h*)
-
-if(NOT "${CPACK_GENERATOR}" STREQUAL "")
-	include(${CMAKE_SOURCE_DIR}/cmake/packages.cmake)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ set(PKG_CONFIG_REQUIRES)
 set(DEB_DEPENDS)
 set(RPM_DEPENDS)
 
-if (ENGINE_CSMAP AND CXX_STANDARD LESS 14)
+if(ENGINE_CSMAP AND CXX_STANDARD LESS 14)
 	message(FATAL_ERROR "CXX_STANDARD must be >= 14 if ENGINE_CSMAP is set")
 endif()
 
@@ -263,14 +263,14 @@ if(DEVELOPER_MODE)
 	if(NOT PERL_FOUND)
 		message(FATAL_ERROR "Perl not found")
 	endif()
-	if (PERL_VERSION_STRING VERSION_LESS 5.16)
+	if(PERL_VERSION_STRING VERSION_LESS 5.16)
 		message(FATAL_ERROR "Minimum required version of Perl is 5.16)")
 	endif()
 
 	execute_process(COMMAND ${PERL_EXECUTABLE} -MText::Diff -e ""
 			ERROR_QUIET
 			RESULT_VARIABLE PERL_TEXT_DIFF_STATUS)
-	if (PERL_TEXT_DIFF_STATUS)
+	if(PERL_TEXT_DIFF_STATUS)
 		message(FATAL_ERROR "Text::Diff Perl module not found (install libtext-diff-perl or perl-Text-Diff)")
 	endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -247,7 +247,7 @@ add_custom_target(check-whitespace-main
 add_dependencies(check-whitespace check-whitespace-main)
 
 if(CHECK_CPP_STYLE)
-	find_program(CLANG_FORMAT NAMES clang-format clang-format-9.0)
+	find_program(CLANG_FORMAT NAMES clang-format clang-format-9 clang-format-9.0)
 	set(CLANG_FORMAT_REQUIRED "9.0")
 	if(CLANG_FORMAT)
 		get_program_version_major_minor(${CLANG_FORMAT} CLANG_FORMAT_VERSION)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,6 +152,7 @@ Next we'll walk you through the steps of creating a new engine.
 * In `src/engine.cc`:
     * Add `#include "engines/mytree.h"` (within `#ifdef ENGINE_MYTREE` clause)
     * Update `create_engine` to return new `my_tree` instances
+* In script(s) executed in CIs (at least in `utils/docker/run-test-building.sh`) add a check/build for new engine
 * Build & verify engine now works with high-level bindings (see [README](README.md#language-bindings) for information on current bindings)
 
 ### Documentation

--- a/cmake/packages.cmake
+++ b/cmake/packages.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 
 #
 # packages.cmake - CPack configuration for rpm and deb generation
@@ -50,7 +50,7 @@ set(CPACK_DEBIAN_PACKAGE_NAME "libpmemkv-dev")
 set(CPACK_DEBIAN_PACKAGE_VERSION ${CPACK_PACKAGE_VERSION})
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE amd64)
 set(CPACK_DEBIAN_PACKAGE_DEPENDS ${DEB_PACKAGE_REQUIRES})
-set(CPACK_DEBIAN_PACKAGE_MAINTAINER "lukasz.stolarczuk@intel.com")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "szymon.romik@intel.com")
 
 if("${CPACK_GENERATOR}" STREQUAL "RPM")
 	set(CPACK_PACKAGE_FILE_NAME

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -216,7 +216,7 @@ if(ENGINE_CMAP)
 			SCRIPT pmemobj_based/default.cmake
 			PARAMS 8 50)
 
-	if (TESTS_PMEMOBJ_DRD_HELGRIND)
+	if(TESTS_PMEMOBJ_DRD_HELGRIND)
 		add_engine_test(ENGINE cmap
 				BINARY concurrent_put_get_remove_params
 				TRACERS drd helgrind
@@ -230,7 +230,7 @@ if(ENGINE_CMAP)
 			SCRIPT pmemobj_based/default.cmake
 			PARAMS 8 50 100)
 
-	if (TESTS_PMEMOBJ_DRD_HELGRIND)
+	if(TESTS_PMEMOBJ_DRD_HELGRIND)
 		add_engine_test(ENGINE cmap
 				BINARY concurrent_put_get_remove_gen_params
 				TRACERS drd helgrind
@@ -250,7 +250,7 @@ if(ENGINE_CMAP)
 			SCRIPT pmemobj_based/default.cmake
 			PARAMS 400)
 
-	if (TESTS_PMEMOBJ_DRD_HELGRIND)
+	if(TESTS_PMEMOBJ_DRD_HELGRIND)
 		add_engine_test(ENGINE cmap
 				BINARY concurrent_put_get_remove_single_op_params
 				TRACERS drd helgrind
@@ -302,7 +302,7 @@ if(ENGINE_CMAP)
 			SCRIPT pmemobj_based/default.cmake
 			DB_SIZE 200M)
 
-	if (TESTS_LONG)
+	if(TESTS_LONG)
 		add_engine_test(ENGINE cmap
 				BINARY pmemobj_error_handling_tx_oom
 				TRACERS memcheck
@@ -485,7 +485,7 @@ if(ENGINE_CSMAP)
 			SCRIPT pmemobj_based/default.cmake
 			PARAMS 24 200)
 
-	if (TESTS_PMEMOBJ_DRD_HELGRIND)
+	if(TESTS_PMEMOBJ_DRD_HELGRIND)
 		add_engine_test(ENGINE csmap
 				BINARY concurrent_iterate_params
 				TRACERS drd # helgrind XXX: skip list lock order error
@@ -499,7 +499,7 @@ if(ENGINE_CSMAP)
 			SCRIPT pmemobj_based/default.cmake
 			PARAMS 8 50)
 
-	if (TESTS_PMEMOBJ_DRD_HELGRIND)
+	if(TESTS_PMEMOBJ_DRD_HELGRIND)
 		add_engine_test(ENGINE csmap
 				BINARY concurrent_put_get_remove_params
 				TRACERS drd # helgrind XXX: skip list lock order error
@@ -513,7 +513,7 @@ if(ENGINE_CSMAP)
 			SCRIPT pmemobj_based/default.cmake
 			PARAMS 8 50 100)
 
-	if (TESTS_PMEMOBJ_DRD_HELGRIND)
+	if(TESTS_PMEMOBJ_DRD_HELGRIND)
 		add_engine_test(ENGINE csmap
 				BINARY concurrent_put_get_remove_gen_params
 				TRACERS drd # helgrind XXX: skip list lock order error
@@ -533,7 +533,7 @@ if(ENGINE_CSMAP)
 			SCRIPT pmemobj_based/default.cmake
 			PARAMS 400)
 
-	if (TESTS_PMEMOBJ_DRD_HELGRIND)
+	if(TESTS_PMEMOBJ_DRD_HELGRIND)
 		add_engine_test(ENGINE csmap
 				BINARY concurrent_put_get_remove_single_op_params
 				TRACERS drd # helgrind XXX: skip list lock order error
@@ -585,7 +585,7 @@ if(ENGINE_CSMAP)
 			SCRIPT pmemobj_based/default.cmake
 			DB_SIZE 200M)
 
-	if (TESTS_LONG)
+	if(TESTS_LONG)
 		add_engine_test(ENGINE csmap
 				BINARY pmemobj_error_handling_tx_oom
 				TRACERS memcheck

--- a/travis.yml
+++ b/travis.yml
@@ -12,15 +12,16 @@ env:
     - GITHUB_REPO=pmem/pmemkv
     - DOCKERHUB_REPO=pmem/pmemkv
   matrix:
-    - TYPE=normal OS=fedora OS_VER=31
-    - TYPE=normal OS=ubuntu OS_VER=19.10
-    - TYPE=normal OS=ubuntu OS_VER=19.10 COVERAGE=1
+    - TYPE=debug OS=fedora OS_VER=31
+    - TYPE=debug OS=ubuntu OS_VER=19.10 COVERAGE=1
+    - TYPE=release OS=fedora OS_VER=31
+    - TYPE=release OS=ubuntu OS_VER=19.10
     - TYPE=valgrind OS=ubuntu OS_VER=19.10
     - TYPE=memcheck_drd OS=ubuntu OS_VER=19.10
-    - TYPE=building OS=fedora OS_VER=31 COVERAGE=1 PUSH_IMAGE=1 AUTO_DOC_UPDATE=1
-    - TYPE=building OS=ubuntu OS_VER=19.10 COVERAGE=1 PUSH_IMAGE=1
-    - TYPE=bindings OS=ubuntu OS_VER=19.10_bindings PUSH_IMAGE=1
+    - TYPE=building OS=fedora OS_VER=31 PUSH_IMAGE=1 AUTO_DOC_UPDATE=1
+    - TYPE=building OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1 COVERAGE=1
     - TYPE=compatibility OS=fedora OS_VER=31
+    - TYPE=bindings OS=ubuntu OS_VER=19.10_bindings PUSH_IMAGE=1
     - TYPE=coverity OS=ubuntu OS_VER=19.10
 
 before_install:

--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -52,10 +52,14 @@ containerName=pmemkv-${OS}-${OS_VER}
 
 if [[ "$command" == "" ]]; then
 	case $TYPE in
-		normal)
+		debug)
 			builds=(tests_gcc_debug_cpp11
-					tests_gcc_debug_cpp14
-					test_installation)
+					tests_gcc_debug_cpp14)
+			command="./run-build.sh ${builds[@]}";
+			;;
+		release)
+			builds=(tests_clang_release_cpp20
+					test_release_installation)
 			command="./run-build.sh ${builds[@]}";
 			;;
 		valgrind)

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -3,7 +3,8 @@
 # Copyright 2019-2020, Intel Corporation
 
 #
-# prepare-for-build.sh - prepare the Docker image for the build
+# prepare-for-build.sh - prepare the Docker image for the builds
+#                        and defines functions for other scripts.
 #
 
 set -e
@@ -15,13 +16,6 @@ function sudo_password() {
 	echo $USERPASS | sudo -Sk $*
 }
 
-function cleanup() {
-	find . -name ".coverage" -exec rm {} \;
-	find . -name "coverage.xml" -exec rm {} \;
-	find . -name "*.gcov" -exec rm {} \;
-	find . -name "*.gcda" -exec rm {} \;
-}
-
 function upload_codecov() {
 	clang_used=$(cmake -LA -N . | grep CMAKE_CXX_COMPILER | grep clang | wc -c)
 
@@ -31,9 +25,13 @@ function upload_codecov() {
 		gcovexe="gcov"
 	fi
 
-	# the output is redundant in this case, i.e. we rely on parsed report from codecov on github
+	# run gcov exe, using their bash (set flag and remove parsed coverage files)
 	bash <(curl -s https://codecov.io/bash) -c -F $1 -x "$gcovexe"
-	cleanup
+
+	find . -name ".coverage" -exec rm {} \;
+	find . -name "coverage.xml" -exec rm {} \;
+	find . -name "*.gcov" -exec rm {} \;
+	find . -name "*.gcda" -exec rm {} \;
 }
 
 function compile_example_standalone() {

--- a/utils/docker/prepare-for-build.sh
+++ b/utils/docker/prepare-for-build.sh
@@ -12,6 +12,12 @@ set -e
 EXAMPLE_TEST_DIR="/tmp/build_example"
 PREFIX=/usr
 
+# CMake's version assigned to variable(s) (a single number representation for easier comparison)
+CMAKE_VERSION=$(cmake --version | head -n1 | grep -oE '[0-9].[0-9]*')
+CMAKE_VERSION_MAJOR=$(echo $CMAKE_VERSION | cut -d. -f1)
+CMAKE_VERSION_MINOR=$(echo $CMAKE_VERSION | cut -d. -f2)
+CMAKE_VERSION_NUMBER=$((100 * $CMAKE_VERSION_MAJOR + $CMAKE_VERSION_MINOR))
+
 function sudo_password() {
 	echo $USERPASS | sudo -Sk $*
 }

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -4,7 +4,7 @@
 
 #
 # run-build.sh - is called inside a Docker container,
-#                starts pmemkv build with tests.
+#                starts pmemkv builds (defined by the CI jobs) with tests.
 #
 
 set -e
@@ -17,14 +17,9 @@ BUILD_JSON_CONFIG=${BUILD_JSON_CONFIG:-ON}
 CHECK_CPP_STYLE=${CHECK_CPP_STYLE:-ON}
 TESTS_LONG=${TESTS_LONG:-OFF}
 
-cd $WORKDIR
-
-echo
-echo "### Making sure there is no libpmemkv currently installed"
-echo "---------------------------- Error expected! ------------------------------"
-compile_example_standalone pmemkv_basic_cpp && exit 1
-echo "---------------------------------------------------------------------------"
-
+###############################################################################
+# BUILD tests_gcc_debug_cpp11
+###############################################################################
 function tests_gcc_debug_cpp11() {
 	printf "\n$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} START$(tput sgr 0)\n"
 	mkdir build
@@ -58,6 +53,9 @@ function tests_gcc_debug_cpp11() {
 	printf "$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} END$(tput sgr 0)\n\n"
 }
 
+###############################################################################
+# BUILD tests_gcc_debug_cpp14
+###############################################################################
 function tests_gcc_debug_cpp14() {
 	printf "\n$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} START$(tput sgr 0)\n"
 	mkdir build
@@ -90,6 +88,9 @@ function tests_gcc_debug_cpp14() {
 	printf "$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} END$(tput sgr 0)\n\n"
 }
 
+###############################################################################
+# BUILD tests_gcc_debug_cpp14_valgrind_other
+###############################################################################
 function tests_gcc_debug_cpp14_valgrind_other() {
 	printf "\n$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} START$(tput sgr 0)\n"
 	mkdir build
@@ -120,6 +121,9 @@ function tests_gcc_debug_cpp14_valgrind_other() {
 	printf "$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} END$(tput sgr 0)\n\n"
 }
 
+###############################################################################
+# BUILD tests_gcc_debug_cpp14_valgrind_memcheck_drd
+###############################################################################
 function tests_gcc_debug_cpp14_valgrind_memcheck_drd() {
 	printf "\n$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} START$(tput sgr 0)\n"
 	mkdir build
@@ -150,6 +154,9 @@ function tests_gcc_debug_cpp14_valgrind_memcheck_drd() {
 	printf "$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} END$(tput sgr 0)\n\n"
 }
 
+###############################################################################
+# BUILD test_installation
+###############################################################################
 function test_installation() {
 	printf "\n$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} START$(tput sgr 0)\n"
 	mkdir build
@@ -191,7 +198,16 @@ function test_installation() {
 	printf "$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} END$(tput sgr 0)\n\n"
 }
 
-#Run build steps passed as script arguments
+# Main:
+cd $WORKDIR
+
+echo
+echo "### Making sure there is no libpmemkv currently installed"
+echo "---------------------------- Error expected! ------------------------------"
+compile_example_standalone pmemkv_basic_cpp && exit 1
+echo "---------------------------------------------------------------------------"
+
+# Run build steps passed as script arguments
 build_steps=$@
 for build in $build_steps
 do

--- a/utils/docker/run-build.sh
+++ b/utils/docker/run-build.sh
@@ -44,7 +44,7 @@ function tests_gcc_debug_cpp11() {
 	ctest -E "_memcheck|_drd|_helgrind|_pmemcheck|_pmreorder" --timeout 590 --output-on-failure
 
 	if [ "$COVERAGE" == "1" ]; then
-		upload_codecov tests
+		upload_codecov gcc_debug_cpp11
 	fi
 
 	cd ..
@@ -79,7 +79,7 @@ function tests_gcc_debug_cpp14() {
 	ctest -E "_memcheck|_drd|_helgrind|_pmemcheck|_pmreorder" --timeout 590 --output-on-failure
 
 	if [ "$COVERAGE" == "1" ]; then
-		upload_codecov tests
+		upload_codecov gcc_debug_cpp14
 	fi
 
 	cd ..
@@ -112,7 +112,7 @@ function tests_gcc_debug_cpp14_valgrind_other() {
 	ctest -E "_none|_memcheck|_drd" --timeout 590 --output-on-failure
 
 	if [ "$COVERAGE" == "1" ]; then
-		upload_codecov tests
+		upload_codecov gcc_debug_cpp14_valgrind_other
 	fi
 
 	cd ..
@@ -145,7 +145,7 @@ function tests_gcc_debug_cpp14_valgrind_memcheck_drd() {
 	ctest -R "_memcheck|_drd" --timeout 590 --output-on-failure
 
 	if [ "$COVERAGE" == "1" ]; then
-		upload_codecov tests
+		upload_codecov gcc_debug_cpp14_valgrind_memcheck_drd
 	fi
 
 	cd ..

--- a/utils/docker/run-test-building.sh
+++ b/utils/docker/run-test-building.sh
@@ -206,7 +206,7 @@ do
 	ctest -R wrong_engine_name_test --output-on-failure
 
 	if [ "$COVERAGE" == "1" ]; then
-		upload_codecov tests
+		upload_codecov wrong_engine_names
 	fi
 
 	cd $WORKDIR

--- a/utils/docker/run-test-building.sh
+++ b/utils/docker/run-test-building.sh
@@ -45,37 +45,6 @@ function test_gcc_cpp20() {
 }
 
 ###############################################################################
-# BUILD test_clang_cpp20 llvm
-###############################################################################
-function test_clang_cpp20() {
-	printf "\n$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} START$(tput sgr 0)\n"
-	CWD=$(pwd)
-	echo
-	echo "##############################################################"
-	echo "### Checking C++20 support in clang++"
-	echo "##############################################################"
-	mkdir $WORKDIR/build
-	cd $WORKDIR/build
-
-	CC=clang CXX=clang++ cmake .. -DCMAKE_BUILD_TYPE=Release \
-		-DTEST_DIR=$TEST_DIR \
-		-DCMAKE_INSTALL_PREFIX=$PREFIX \
-		-DBUILD_JSON_CONFIG=${BUILD_JSON_CONFIG} \
-		-DCOVERAGE=$COVERAGE \
-		-DDEVELOPER_MODE=1 \
-		-DCXX_STANDARD=20
-
-	make -j$(nproc)
-	# Run basic tests
-	ctest -R "SimpleTest" --output-on-failure
-
-	cd $CWD
-	rm -rf $WORKDIR/build
-
-	printf "$(tput setaf 1)$(tput setab 7)BUILD ${FUNCNAME[0]} END$(tput sgr 0)\n\n"
-}
-
-###############################################################################
 # BUILD test_building_of_packages
 ###############################################################################
 function test_building_of_packages() {
@@ -155,15 +124,9 @@ function build_with_flags() {
 # Main:
 cd $WORKDIR
 
-CMAKE_VERSION=$(cmake --version | head -n1 | grep -oE '[0-9].[0-9]*')
-CMAKE_VERSION_MAJOR=$(echo $CMAKE_VERSION | cut -d. -f1)
-CMAKE_VERSION_MINOR=$(echo $CMAKE_VERSION | cut -d. -f2)
-CMAKE_VERSION_NUMBER=$((100 * $CMAKE_VERSION_MAJOR + $CMAKE_VERSION_MINOR))
-
 # CXX_STANDARD==20 is supported since CMake 3.12
 if [ $CMAKE_VERSION_NUMBER -ge 312 ]; then
 	test_gcc_cpp20
-	test_clang_cpp20
 fi
 
 echo


### PR DESCRIPTION
major changes:
- add new release and clang builds in CI (#693)
- run coverage on Ubuntu and on Travis only
- major cleanup in top-level CMake (I've tested it locally with various settings and it seems to work properly ;) )
- unify builds logs in run-*.sh scripts
- upload gcov reports with more specific names/flags (not just "tests")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/704)
<!-- Reviewable:end -->
