### PR TITLE
force removal of docs' dir since it might not exist yet

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -57,7 +57,7 @@ git checkout -B $GH_PAGES_NAME upstream/gh-pages
 git clean -dfx
 
 # Clean old content, since some files might have been deleted
-rm -r ./${VERSION}
+rm -rf ./${VERSION}
 mkdir -p ./${VERSION}/manpages/
 mkdir -p ./${VERSION}/doxygen/
 


### PR DESCRIPTION
it's required for docs to be generated on stable-1.2 branch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/714)
<!-- Reviewable:end -->
