### PR TITLE
tests: escape command params before pasing them to pmreorder

### DIFF
--- a/tests/helpers.cmake
+++ b/tests/helpers.cmake
@@ -295,10 +295,12 @@ function(pmreorder_execute expect_success engine conf_file name)
 
     set(ENV{PMEMOBJ_CONF} "copy_on_write.at_open=1")
 
+    string(REPLACE "\"" "\\\"" ESCAPED_ARGN "${ARGN}")
+
     set(cmd pmreorder -l ${BIN_DIR}/${TEST_NAME}.storelog
                     -o ${BIN_DIR}/${TEST_NAME}.pmreorder
                     -r ${engine}
-                    -p "${name} ${ARGN}"
+                    -p "${name} ${ESCAPED_ARGN}"
                     -x ${conf_file})
 
     execute_common(${expect_success} ${TRACER}_${TESTCASE} ${cmd})


### PR DESCRIPTION
Parameters for pmreorder are passed within "" so if there are
any quoutes inside we must escape them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/729)
<!-- Reviewable:end -->
