### PR TITLE
Bump dockerimages to lts

### DIFF
--- a/tests/config/config_cpp.cc
+++ b/tests/config/config_cpp.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Intel Corporation
+ * Copyright 2019-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -113,7 +113,7 @@ TEST_F(ConfigCppTest, SimpleTest_TRACERS_M)
 	ASSERT_EQ(value_custom_ptr_deleter->b, 'b');
 
 	custom_type *value_custom;
-	size_t value_custom_count;
+	size_t value_custom_count = 0;
 	s = cfg->get_data("object", value_custom, value_custom_count);
 	ASSERT_EQ(s, status::OK);
 	ASSERT_EQ(value_custom_count, 1U);
@@ -121,7 +121,7 @@ TEST_F(ConfigCppTest, SimpleTest_TRACERS_M)
 	ASSERT_EQ(value_custom->b, 'a');
 
 	int *value_array;
-	size_t value_array_count;
+	size_t value_array_count = 0;
 	s = cfg->get_data("array", value_array, value_array_count);
 	ASSERT_EQ(s, status::OK);
 	ASSERT_EQ(value_array_count, 3U);

--- a/tests/pmemkv_c_api_test.cc
+++ b/tests/pmemkv_c_api_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Intel Corporation
+ * Copyright 2019-2020, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -39,6 +39,11 @@
 
 // Tests and params' list
 #include "basic_tests.h"
+
+// Workaround to support gtest in versions 1.8.1 and 1.10
+#ifndef INSTANTIATE_TEST_SUITE_P
+#define INSTANTIATE_TEST_SUITE_P INSTANTIATE_TEST_CASE_P
+#endif
 
 class PmemkvCApiTest : public ::testing::TestWithParam<Basic> {
 public:
@@ -188,5 +193,5 @@ TEST_P(PmemkvCApiTest, NullConfig)
 	ASSERT_TRUE(s == PMEMKV_STATUS_INVALID_ARGUMENT) << pmemkv_errormsg();
 }
 
-INSTANTIATE_TEST_CASE_P(basic_tests, PmemkvCApiTest, ::testing::ValuesIn(basic_tests),
-			GetTestName());
+INSTANTIATE_TEST_SUITE_P(basic_tests, PmemkvCApiTest, ::testing::ValuesIn(basic_tests),
+			 GetTestName());

--- a/travis.yml
+++ b/travis.yml
@@ -10,6 +10,7 @@ services:
 env:
   matrix:
     - TYPE=normal OS=fedora OS_VER=31
+    - TYPE=normal OS=ubuntu OS_VER=19.10
     - TYPE=normal OS=ubuntu OS_VER=20.04
     - TYPE=normal OS=ubuntu OS_VER=20.04 COVERAGE=1
     - TYPE=building OS=fedora OS_VER=31 COVERAGE=1 PUSH_IMAGE=1

--- a/travis.yml
+++ b/travis.yml
@@ -9,13 +9,13 @@ services:
 
 env:
   matrix:
-    - TYPE=normal OS=fedora OS_VER=30
-    - TYPE=normal OS=ubuntu OS_VER=19.04
-    - TYPE=normal OS=ubuntu OS_VER=19.04 COVERAGE=1
-    - TYPE=building OS=fedora OS_VER=30 COVERAGE=1 PUSH_IMAGE=1
-    - TYPE=building OS=ubuntu OS_VER=19.04 COVERAGE=1 PUSH_IMAGE=1 AUTO_DOC_UPDATE=1
-    - TYPE=bindings OS=ubuntu OS_VER=19.04_bindings PUSH_IMAGE=1
-    - TYPE=coverity OS=ubuntu OS_VER=19.04
+    - TYPE=normal OS=fedora OS_VER=31
+    - TYPE=normal OS=ubuntu OS_VER=20.04
+    - TYPE=normal OS=ubuntu OS_VER=20.04 COVERAGE=1
+    - TYPE=building OS=fedora OS_VER=31 COVERAGE=1 PUSH_IMAGE=1
+    - TYPE=building OS=ubuntu OS_VER=20.04 COVERAGE=1 PUSH_IMAGE=1 AUTO_DOC_UPDATE=1
+    - TYPE=bindings OS=ubuntu OS_VER=20.04_bindings PUSH_IMAGE=1
+    - TYPE=coverity OS=ubuntu OS_VER=20.04
 
 before_install:
   - echo $TRAVIS_COMMIT_RANGE

--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -61,7 +61,6 @@ RUN dnf update -y \
 	pandoc \
 	passwd \
 	perl-Text-Diff \
-	rapidjson-devel \
 	rpm-build \
 	sudo \
 	tbb-devel \
@@ -72,6 +71,10 @@ RUN dnf update -y \
 
 # Install glibc-debuginfo
 RUN dnf debuginfo-install -y glibc
+
+# Install rapidjson from sources
+COPY install-rapidjson.sh install-rapidjson.sh
+RUN ./install-rapidjson.sh
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,50 +30,48 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
+# Dockerfile - a 'recipe' for Docker to build an image of Fedora-based
 #              environment prepared for running pmemkv build and tests.
 #
 
 # Pull base image
-FROM ubuntu:19.04
+FROM fedora:31
 MAINTAINER lukasz.stolarczuk@intel.com
 
-# Update the Apt cache and install basic tools
-RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+# Install basic tools
+RUN dnf update -y \
+ && dnf install -y \
 	autoconf \
 	automake \
-	build-essential \
 	clang \
-	clang-format \
 	cmake \
-	curl \
-	debhelper \
-	devscripts \
+	daxctl-devel \
 	doxygen \
-	fakeroot \
+	gcc \
+	gcc-c++ \
+	gdb \
 	git \
 	graphviz \
-	hub \
-	libc6-dbg \
-	libdaxctl-dev \
-	libgtest-dev \
-	libndctl-dev \
-	libnode-dev \
-	libnuma-dev \
-	libtbb-dev \
-	libtext-diff-perl \
+	gtest-devel \
 	libtool \
-	libunwind8-dev \
-	numactl \
+	make \
+	man \
+	ndctl-devel \
+	numactl-devel \
 	pandoc \
-	pkg-config \
-	rapidjson-dev \
-	ruby \
+	passwd \
+	perl-Text-Diff \
+	rapidjson-devel \
+	rpm-build \
 	sudo \
+	tbb-devel \
+	unzip \
 	wget \
-	whois \
- && rm -rf /var/lib/apt/lists/*
+	which \
+&& dnf clean all
+
+# Install glibc-debuginfo
+RUN dnf debuginfo-install -y glibc
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh
@@ -81,11 +79,11 @@ RUN ./install-valgrind.sh
 
 # Install pmdk
 COPY install-pmdk.sh install-pmdk.sh
-RUN ./install-pmdk.sh dpkg
+RUN ./install-pmdk.sh rpm
 
 # Install pmdk c++ bindings
 COPY install-libpmemobj-cpp.sh install-libpmemobj-cpp.sh
-RUN ./install-libpmemobj-cpp.sh DEB
+RUN ./install-libpmemobj-cpp.sh RPM
 
 # Install memkind
 COPY install-memkind.sh install-memkind.sh
@@ -94,11 +92,14 @@ RUN ./install-memkind.sh
 # Add user
 ENV USER user
 ENV USERPASS pass
-RUN useradd -m $USER -g sudo -p `mkpasswd $USERPASS`
+RUN useradd -m $USER
+RUN echo $USERPASS | passwd $USER --stdin
+RUN gpasswd wheel -a $USER
 USER $USER
 
 # Set required environment variables
-ENV OS ubuntu
-ENV OS_VER 19.04
-ENV PACKAGE_MANAGER deb
+ENV OS fedora
+ENV OS_VER 31
+ENV PACKAGE_MANAGER rpm
 ENV NOTTY 1
+

--- a/utils/docker/images/Dockerfile.ubuntu-19.10
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10
@@ -32,11 +32,12 @@
 #
 # Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
 #              environment prepared for running pmemkv build and tests.
+#              Separate build for testing rapidjson installed from package.
 #
 
 # Pull base image
-FROM ubuntu:20.04
-MAINTAINER lukasz.stolarczuk@intel.com
+FROM ubuntu:19.10
+MAINTAINER szymon.romik@intel.com
 
 # Update the Apt cache and install basic tools
 RUN apt-get update
@@ -50,11 +51,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	curl \
 	debhelper \
 	devscripts \
-	doxygen \
 	fakeroot \
 	git \
-	graphviz \
-	hub \
 	libc6-dbg \
 	libdaxctl-dev \
 	libgtest-dev \
@@ -68,15 +66,12 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	numactl \
 	pandoc \
 	pkg-config \
+	rapidjson-dev \
 	ruby \
 	sudo \
 	wget \
 	whois \
  && rm -rf /var/lib/apt/lists/*
-
-# Install rapidjson from sources
-COPY install-rapidjson.sh install-rapidjson.sh
-RUN ./install-rapidjson.sh
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh
@@ -102,6 +97,6 @@ USER $USER
 
 # Set required environment variables
 ENV OS ubuntu
-ENV OS_VER 20.04
+ENV OS_VER 19.10
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1

--- a/utils/docker/images/Dockerfile.ubuntu-20.04
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -30,48 +30,50 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #
-# Dockerfile - a 'recipe' for Docker to build an image of Fedora-based
+# Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
 #              environment prepared for running pmemkv build and tests.
 #
 
 # Pull base image
-FROM fedora:30
+FROM ubuntu:20.04
 MAINTAINER lukasz.stolarczuk@intel.com
 
-# Install basic tools
-RUN dnf update -y \
- && dnf install -y \
+# Update the Apt cache and install basic tools
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	autoconf \
 	automake \
+	build-essential \
 	clang \
+	clang-format \
 	cmake \
-	daxctl-devel \
+	curl \
+	debhelper \
+	devscripts \
 	doxygen \
-	gcc \
-	gcc-c++ \
-	gdb \
+	fakeroot \
 	git \
 	graphviz \
-	gtest-devel \
+	hub \
+	libc6-dbg \
+	libdaxctl-dev \
+	libgtest-dev \
+	libndctl-dev \
+	libnode-dev \
+	libnuma-dev \
+	libtbb-dev \
+	libtext-diff-perl \
 	libtool \
-	make \
-	man \
-	ndctl-devel \
-	numactl-devel \
+	libunwind8-dev \
+	numactl \
 	pandoc \
-	passwd \
-	perl-Text-Diff \
-	rapidjson-devel \
-	rpm-build \
+	pkg-config \
+	rapidjson-dev \
+	ruby \
 	sudo \
-	tbb-devel \
-	unzip \
 	wget \
-	which \
-&& dnf clean all
-
-# Install glibc-debuginfo
-RUN dnf debuginfo-install -y glibc
+	whois \
+ && rm -rf /var/lib/apt/lists/*
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh
@@ -79,11 +81,11 @@ RUN ./install-valgrind.sh
 
 # Install pmdk
 COPY install-pmdk.sh install-pmdk.sh
-RUN ./install-pmdk.sh rpm
+RUN ./install-pmdk.sh dpkg
 
 # Install pmdk c++ bindings
 COPY install-libpmemobj-cpp.sh install-libpmemobj-cpp.sh
-RUN ./install-libpmemobj-cpp.sh RPM
+RUN ./install-libpmemobj-cpp.sh DEB
 
 # Install memkind
 COPY install-memkind.sh install-memkind.sh
@@ -92,14 +94,11 @@ RUN ./install-memkind.sh
 # Add user
 ENV USER user
 ENV USERPASS pass
-RUN useradd -m $USER
-RUN echo $USERPASS | passwd $USER --stdin
-RUN gpasswd wheel -a $USER
+RUN useradd -m $USER -g sudo -p `mkpasswd $USERPASS`
 USER $USER
 
 # Set required environment variables
-ENV OS fedora
-ENV OS_VER 30
-ENV PACKAGE_MANAGER rpm
+ENV OS ubuntu
+ENV OS_VER 20.04
+ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
-

--- a/utils/docker/images/Dockerfile.ubuntu-20.04
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04
@@ -45,7 +45,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	automake \
 	build-essential \
 	clang \
-	clang-format \
+	clang-format-8 \
 	cmake \
 	curl \
 	debhelper \

--- a/utils/docker/images/Dockerfile.ubuntu-20.04_bindings
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04_bindings
@@ -73,7 +73,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	pkg-config \
 	python3-dev \
 	python3-distutils \
-	rapidjson-dev \
 	ruby-dev \
 	sudo \
 	wget \
@@ -83,6 +82,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 # Install Googletest
 COPY install-googletest.sh install-googletest.sh
 RUN ./install-googletest.sh
+
+# Install rapidjson from sources
+COPY install-rapidjson.sh install-rapidjson.sh
+RUN ./install-rapidjson.sh
 
 # Install valgrind
 COPY install-valgrind.sh install-valgrind.sh

--- a/utils/docker/images/Dockerfile.ubuntu-20.04_bindings
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04_bindings
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@
 #
 
 # Pull base image
-FROM ubuntu:19.04
+FROM ubuntu:20.04
 MAINTAINER lukasz.stolarczuk@intel.com
 
 # Update the Apt cache and install basic tools
@@ -112,6 +112,6 @@ USER $USER
 
 # Set required environment variables
 ENV OS ubuntu
-ENV OS_VER 19.04
+ENV OS_VER 20.04
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1

--- a/utils/docker/images/Dockerfile.ubuntu-20.04_bindings
+++ b/utils/docker/images/Dockerfile.ubuntu-20.04_bindings
@@ -46,7 +46,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	automake \
 	build-essential \
 	clang \
-	clang-format \
+	clang-format-8 \
 	cmake \
 	curl \
 	debhelper \


### PR DESCRIPTION
this in ref. to #667 - we decided to bump docker versions on all branches.
Ubuntu to LTS and Fedora to a bit newer - 31; not 32, because it has an issue with clang, and on stable-1.0 we don't have CHECK_CPP_STYLE variable yet.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/731)
<!-- Reviewable:end -->
