### PR TITLE
cleanup packages in Ubuntu and Fedora docker images

### DIFF
--- a/utils/docker/images/Dockerfile.fedora-31
+++ b/utils/docker/images/Dockerfile.fedora-31
@@ -35,6 +35,7 @@ RUN dnf update -y \
 	gdb \
 	git \
 	graphviz \
+	gzip \
 	hub \
 	libtool \
 	libunwind-devel \
@@ -50,7 +51,6 @@ RUN dnf update -y \
 	rpm-build \
 	sudo \
 	tbb-devel \
-	unzip \
 	wget \
 	which \
 && dnf clean all

--- a/utils/docker/images/Dockerfile.ubuntu-19.10
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10
@@ -36,8 +36,10 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	devscripts \
 	doxygen \
 	fakeroot \
+	gdb \
 	git \
 	graphviz \
+	gzip \
 	libc6-dbg \
 	libdaxctl-dev \
 	libndctl-dev \
@@ -52,7 +54,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	pandoc \
 	pkg-config \
 	rapidjson-dev \
-	ruby \
 	sudo \
 	wget \
 	whois \


### PR DESCRIPTION
we need gdb for tests;
we don't need unzip, rather gzip;
ruby is also not needed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/737)
<!-- Reviewable:end -->
