### PR TITLE
set TERM variable in docker

### DIFF
--- a/utils/docker/build.sh
+++ b/utils/docker/build.sh
@@ -120,6 +120,7 @@ docker run --privileged=true --name=$containerName -i $TTY \
 	${docker_opts} \
 	--env http_proxy=$http_proxy \
 	--env https_proxy=$https_proxy \
+	--env TERM=xterm-256color \
 	--env WORKDIR=$WORKDIR \
 	--env SCRIPTSDIR=$SCRIPTSDIR \
 	--env COVERAGE=$COVERAGE \


### PR DESCRIPTION
to avoid error "tput: No value for $TERM and no -T specified", while executing run-*.sh on GHA.


It's used e.g. here: https://github.com/pmem/pmemkv/blob/master/utils/docker/run-build.sh#L24

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/739)
<!-- Reviewable:end -->
