### PR TITLE
Add missing packages in docker images

### DIFF
--- a/utils/docker/images/Dockerfile.archlinux-base-latest
+++ b/utils/docker/images/Dockerfile.archlinux-base-latest
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of archlinux-based
@@ -35,6 +35,7 @@ RUN pacman -S --noconfirm \
 	gdb \
 	git \
 	graphviz \
+	gzip \
 	intel-tbb \
 	libunwind \
 	llvm \
@@ -44,7 +45,6 @@ RUN pacman -S --noconfirm \
 	perl-text-diff \
 	pkg-config \
 	rapidjson \
-	ruby \
 	sfml \
 	sudo \
 	wget \

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -40,6 +40,8 @@ RUN dnf update -y \
 	gdb \
 	git \
 	graphviz \
+	gzip \
+	libunwind-devel \
 	libtool \
 	make \
 	man \
@@ -49,10 +51,10 @@ RUN dnf update -y \
 	passwd \
 	perl-Text-Diff \
 	python36 \
+	rapidjson-devel \
 	rpm-build \
 	sudo \
 	tbb-devel \
-	unzip \
 	wget \
 	which \
 && dnf clean all

--- a/utils/docker/images/Dockerfile.debian-testing
+++ b/utils/docker/images/Dockerfile.debian-testing
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of debian-based
@@ -28,7 +28,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	automake \
 	build-essential \
 	clang \
-	clang-format \
+	clang-format-9 \
 	cmake \
 	curl \
 	debhelper \
@@ -36,7 +36,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	doxygen \
 	fakeroot \
 	git \
+	gdb \
 	graphviz \
+	gzip \
 	libc6-dbg \
 	libdaxctl-dev \
 	libndctl-dev \
@@ -51,7 +53,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	pandoc \
 	pkg-config \
 	rapidjson-dev \
-	ruby \
 	sudo \
 	wget \
 	whois \

--- a/utils/docker/images/Dockerfile.debian-unstable
+++ b/utils/docker/images/Dockerfile.debian-unstable
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of debian-based
@@ -28,7 +28,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	automake \
 	build-essential \
 	clang \
-	clang-format \
+	clang-format-9 \
 	cmake \
 	curl \
 	debhelper \
@@ -36,7 +36,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	doxygen \
 	fakeroot \
 	git \
+	gdb \
 	graphviz \
+	gzip \
 	libc6-dbg \
 	libdaxctl-dev \
 	libndctl-dev \
@@ -51,7 +53,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	pandoc \
 	pkg-config \
 	rapidjson-dev \
-	ruby \
 	sudo \
 	wget \
 	whois \

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of Fedora-based
@@ -26,7 +26,7 @@ RUN dnf update -y \
  && dnf install -y \
 	autoconf \
 	automake \
-	clang9.0-devel \
+	clang \
 	cmake \
 	daxctl-devel \
 	doxygen \
@@ -35,7 +35,7 @@ RUN dnf update -y \
 	gdb \
 	git \
 	graphviz \
-	hub \
+	gzip \
 	libtool \
 	libunwind-devel \
 	make \

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of opensuse-based
@@ -41,7 +41,7 @@ RUN zypper install -y \
 	gdb \
 	git \
 	graphviz \
-	hub \
+	gzip \
 	keyutils-devel \
 	libtool \
 	make \
@@ -51,6 +51,7 @@ RUN zypper install -y \
 	libndctl-devel \
 	libnuma-devel \
 	libudev-devel \
+	libunwind-devel \
 	libuuid-devel \
 	pandoc \
 	perl-Text-Diff \

--- a/utils/docker/images/Dockerfile.opensuse-leap-latest
+++ b/utils/docker/images/Dockerfile.opensuse-leap-latest
@@ -43,13 +43,14 @@ RUN zypper install -y \
 	graphviz \
 	gzip \
 	keyutils-devel \
-	libtool \
 	make \
 	man \
+	memkind-devel \
 	libjson-c-devel \
 	libkmod-devel \
 	libndctl-devel \
 	libnuma-devel \
+	libtool \
 	libudev-devel \
 	libunwind-devel \
 	libuuid-devel \
@@ -90,10 +91,6 @@ RUN ./install-pmdk.sh rpm
 # Install pmdk c++ bindings
 COPY install-libpmemobj-cpp.sh install-libpmemobj-cpp.sh
 RUN ./install-libpmemobj-cpp.sh RPM
-
-# Install memkind
-COPY install-memkind.sh install-memkind.sh
-RUN ./install-memkind.sh opensuse
 
 # Add user
 ENV USER user

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -47,13 +47,14 @@ RUN zypper install -y \
 	graphviz \
 	gzip \
 	keyutils-devel \
-	libtool \
 	make \
 	man \
+	memkind-devel \
 	libjson-c-devel \
 	libkmod-devel \
 	libndctl-devel \
 	libnuma-devel \
+	libtool \
 	libudev-devel \
 	libunwind-devel \
 	libuuid-devel \
@@ -84,10 +85,6 @@ RUN ./install-pmdk.sh rpm
 # Install pmdk c++ bindings
 COPY install-libpmemobj-cpp.sh install-libpmemobj-cpp.sh
 RUN ./install-libpmemobj-cpp.sh RPM
-
-# Install memkind
-COPY install-memkind.sh install-memkind.sh
-RUN ./install-memkind.sh opensuse
 
 # Add user
 ENV USER user

--- a/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
+++ b/utils/docker/images/Dockerfile.opensuse-tumbleweed-latest
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of opensuse-based
@@ -35,7 +35,7 @@ RUN zypper install -y \
 	autoconf \
 	automake \
 	bash-completion \
-	clang \
+	clang9 \
 	cmake \
 	doxygen \
 	fdupes \
@@ -45,7 +45,7 @@ RUN zypper install -y \
 	glibc-debuginfo \
 	git \
 	graphviz \
-	hub \
+	gzip \
 	keyutils-devel \
 	libtool \
 	make \
@@ -55,6 +55,7 @@ RUN zypper install -y \
 	libndctl-devel \
 	libnuma-devel \
 	libudev-devel \
+	libunwind-devel \
 	libuuid-devel \
 	pandoc \
 	perl-Text-Diff \
@@ -63,7 +64,6 @@ RUN zypper install -y \
 	rpm-build \
 	sudo \
 	tbb-devel \
-	unzip \
 	wget \
 	which
 

--- a/utils/docker/images/Dockerfile.ubuntu-19.10
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10
@@ -22,6 +22,10 @@ ARG SKIP_PMDK_BUILD
 ARG SKIP_LIBPMEMOBJCPP_BUILD
 ARG SKIP_SCRIPTS_DOWNLOAD
 
+ENV COVERITY_DEPS "\
+	ruby \
+	wget"
+
 # Update the Apt cache and install basic tools
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -57,6 +61,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	sudo \
 	wget \
 	whois \
+	$COVERITY_DEPS \
  && rm -rf /var/lib/apt/lists/*
 
 # Install valgrind

--- a/utils/docker/images/Dockerfile.ubuntu-rolling
+++ b/utils/docker/images/Dockerfile.ubuntu-rolling
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2016-2019, Intel Corporation
+# Copyright 2016-2020, Intel Corporation
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
@@ -28,15 +28,17 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	automake \
 	build-essential \
 	clang \
-	clang-format \
+	clang-format-9 \
 	cmake \
 	curl \
 	debhelper \
 	devscripts \
 	doxygen \
 	fakeroot \
+	gdb \
 	git \
 	graphviz \
+	gzip \
 	libc6-dbg \
 	libdaxctl-dev \
 	libndctl-dev \
@@ -51,7 +53,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	pandoc \
 	pkg-config \
 	rapidjson-dev \
-	ruby \
 	sudo \
 	wget \
 	whois \

--- a/utils/docker/images/install-memkind.sh
+++ b/utils/docker/images/install-memkind.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 
 #
 # install-memkind.sh <OS> - installs memkind from sources; depends on


### PR DESCRIPTION
- [x] temporary commit (`check building of images`) will be removed

This PR brings packages in "non-standard" docker images up-to-date.
Fedora Rawhide and ArchLinux does not build (issues: [PMDK](https://github.com/pmem/pmdk/issues/4938) & [Memkind](https://github.com/memkind/memkind/issues/317))

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/745)
<!-- Reviewable:end -->
