### PR TITLE
Run most CI jobs on GHA only

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -1,9 +1,7 @@
 #
-# The 'XXX_DISABLE_' suffix is used twice in this file to disable two actions:
-# 1) XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} - disables pushing the rebuilt Docker image,
-# 2) XXX_DISABLE_AUTO_DOC_UPDATE - disables making pull requests with the update of documentation,
-# 3) XXX_COVERAGE - disables uploads of coverage reports.
-# Those two actions are disabled, because they conflict with the same ones run on Travis.
+# The 'XXX_DISABLE_' suffix is used in this file to disable actions:
+# 1) XXX_DISABLE_COVERAGE - disables uploads of coverage reports.
+# These actions are disabled, because they conflict with the same ones run on Travis.
 # Only one CI (Travis or GitHub Actions) can run them at the time, so they can be enabled here,
 # when we decide to switch from Travis to GitHub Actions. The 'XXX_DISABLE_' suffix should be removed then.
 #
@@ -23,21 +21,21 @@ jobs:
     env:
       DOCKERHUB_USER:          ${{ secrets.DOCKERHUB_USER }}
       DOCKERHUB_PASSWORD:      ${{ secrets.DOCKERHUB_PASSWORD }}
+      DOC_UPDATE_GITHUB_TOKEN: ${{ secrets.DOC_UPDATE_GITHUB_TOKEN }}
       HOST_WORKDIR:   /home/runner/work/pmemkv/pmemkv
       WORKDIR:        utils/docker
     strategy:
       matrix:
         CONFIG: ["TYPE=debug OS=fedora OS_VER=31",
-                 "TYPE=debug OS=ubuntu OS_VER=19.10 XXX_COVERAGE=1",
+                 "TYPE=debug OS=ubuntu OS_VER=19.10 XXX_DISABLE_COVERAGE=1",
                  "TYPE=release OS=fedora OS_VER=31",
                  "TYPE=release OS=ubuntu OS_VER=19.10",
                  "TYPE=valgrind OS=ubuntu OS_VER=19.10",
                  "TYPE=memcheck_drd OS=ubuntu OS_VER=19.10",
-                 "TYPE=building OS=fedora OS_VER=31 PUSH_IMAGE=1 XXX_DISABLE_AUTO_DOC_UPDATE=1",
-                 "TYPE=building OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1 XXX_COVERAGE=1",
+                 "TYPE=building OS=fedora OS_VER=31 PUSH_IMAGE=1 AUTO_DOC_UPDATE=1",
+                 "TYPE=building OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1 XXX_DISABLE_COVERAGE=1",
                  "TYPE=compatibility OS=fedora OS_VER=31",
-                 "TYPE=bindings OS=ubuntu OS_VER=19.10_bindings PUSH_IMAGE=1",
-                 "TYPE=coverity OS=ubuntu OS_VER=19.10"]
+                 "TYPE=bindings OS=ubuntu OS_VER=19.10_bindings PUSH_IMAGE=1"]
     steps:
        - name: Clone the git repo
          uses: actions/checkout@v2
@@ -51,4 +49,4 @@ jobs:
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build.sh
 
        - name: Push the image
-         run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f XXX_DISABLE_${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh $OS-$OS_VER; fi"
+         run: cd $WORKDIR && source ./set-vars.sh && ${{ matrix.CONFIG }} /bin/bash -c "if [[ -f ${CI_FILE_PUSH_IMAGE_TO_REPO} ]]; then images/push-image.sh $OS-$OS_VER; fi"

--- a/travis.yml
+++ b/travis.yml
@@ -12,16 +12,8 @@ env:
     - GITHUB_REPO=pmem/pmemkv
     - DOCKERHUB_REPO=pmem/pmemkv
   matrix:
-    - TYPE=debug OS=fedora OS_VER=31
     - TYPE=debug OS=ubuntu OS_VER=19.10 COVERAGE=1
-    - TYPE=release OS=fedora OS_VER=31
-    - TYPE=release OS=ubuntu OS_VER=19.10
-    - TYPE=valgrind OS=ubuntu OS_VER=19.10
-    - TYPE=memcheck_drd OS=ubuntu OS_VER=19.10
-    - TYPE=building OS=fedora OS_VER=31 PUSH_IMAGE=1 AUTO_DOC_UPDATE=1
-    - TYPE=building OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1 COVERAGE=1
-    - TYPE=compatibility OS=fedora OS_VER=31
-    - TYPE=bindings OS=ubuntu OS_VER=19.10_bindings PUSH_IMAGE=1
+    - TYPE=building OS=ubuntu OS_VER=19.10 COVERAGE=1
     - TYPE=coverity OS=ubuntu OS_VER=19.10
 
 before_install:

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -17,7 +17,7 @@ USER_NAME="pmem"
 REPO_NAME="pmemkv"
 CURR_DIR=$(pwd)
 
-ORIGIN="https://${GITHUB_TOKEN}@github.com/${BOT_NAME}/${REPO_NAME}"
+ORIGIN="https://${DOC_UPDATE_GITHUB_TOKEN}@github.com/${BOT_NAME}/${REPO_NAME}"
 UPSTREAM="https://github.com/${USER_NAME}/${REPO_NAME}"
 # master or stable-* branch
 TARGET_BRANCH=${CI_BRANCH}


### PR DESCRIPTION

coverity scans should be moved to a separate cron/onschedule workflow like in [PMDK](https://github.com/pmem/pmdk/commit/1ddb6a5846a0446e0d85d7011c5c78aac440f528#diff-354f30a63fb0907d4ad57269548329e3) + it's perhaps needed a bit refactoring (remove/change some checks in build.sh?) and set up coverity secrets in yaml file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/754)
<!-- Reviewable:end -->
