### PR TITLE
Fix Ubuntu 19.10 push image

### DIFF
--- a/travis.yml
+++ b/travis.yml
@@ -10,7 +10,7 @@ services:
 env:
   matrix:
     - TYPE=normal OS=fedora OS_VER=31
-    - TYPE=normal OS=ubuntu OS_VER=19.10
+    - TYPE=normal OS=ubuntu OS_VER=19.10 PUSH_IMAGE=1
     - TYPE=normal OS=ubuntu OS_VER=20.04
     - TYPE=normal OS=ubuntu OS_VER=20.04 COVERAGE=1
     - TYPE=building OS=fedora OS_VER=31 COVERAGE=1 PUSH_IMAGE=1

--- a/utils/docker/images/Dockerfile.ubuntu-19.10
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10
@@ -31,7 +31,7 @@
 
 #
 # Dockerfile - a 'recipe' for Docker to build an image of ubuntu-based
-#              environment prepared for running pmemkv build and tests.
+#              environment, prepared for running pmemkv build and tests.
 #              Separate build for testing rapidjson installed from package.
 #
 


### PR DESCRIPTION
add missing "push image" param to store docker image in dockerhub

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/770)
<!-- Reviewable:end -->
