### PR TITLE
docker: bump pmemkv-java version

### DIFF
--- a/utils/docker/images/Dockerfile.ubuntu-19.10_bindings
+++ b/utils/docker/images/Dockerfile.ubuntu-19.10_bindings
@@ -16,8 +16,7 @@ ENV OS ubuntu
 ENV OS_VER 19.10_bindings
 ENV PACKAGE_MANAGER deb
 ENV NOTTY 1
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
-ENV JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 # Additional parameters to build docker without building components
 ARG SKIP_VALGRIND_BUILD
@@ -54,7 +53,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 	maven \
 	npm \
 	numactl \
-	openjdk-11-jdk \
+	openjdk-8-jdk \
 	pandoc \
 	pkg-config \
 	python3-dev \

--- a/utils/docker/images/install-bindings-dependencies.sh
+++ b/utils/docker/images/install-bindings-dependencies.sh
@@ -16,11 +16,8 @@ PMEMKV_VERSION="a2a70b994d57dd3fa9edbf0c7c9bbebb01dc2f5f"
 # master: Merge pull request #44 from lukaszstolarczuk/update-tra..., 21.11.2019
 RUBY_VERSION="3741e3df698245fc8a15822a1aa85b5c211fd332"
 
-# master: Merge pull request #34 from igchor/add_pmemkv_errormsg, 06.12.2020
-JNI_VERSION="fcc8370b230ab3236d062a121e22dcebf37b90ec"
-
-# master: Merge pull request #38 from lukaszstolarczuk/update-tra..., 17.03.2020
-JAVA_VERSION="ab8747c3baf4af8cd2ce1985986d7fcc241ccd65"
+# stable-1.0: Merge pull request #86 from lukaszstolarczuk/remov..., 19.08.2020
+JAVA_VERSION="e210e6490092d5aa8afbcc49e504d917f140448a"
 
 # master: Merge pull request #49 from how759/buffer-arguments, 02.03.2020
 NODEJS_VERSION="12ecc0a9c3205425bf0aa1767eada53834535045"
@@ -31,19 +28,20 @@ rm -rf /opt/bindings
 WORKDIR=$(pwd)
 
 #
-# 1) Build and install PMEMKV - Java will need it
+# Build and install PMEMKV - Java will need it
 #
 git clone https://github.com/pmem/pmemkv.git
 cd pmemkv
 git checkout $PMEMKV_VERSION
 mkdir build
 cd build
-# only VSMAP engine is enabled, because Java tests need it
-
+# Pmemkv at this point is needed only to be linked with jni. As tests are skipped,
+# engines are not needed.
 cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DCMAKE_INSTALL_PREFIX=$PREFIX \
-	-DENGINE_VSMAP=ON \
+	-DENGINE_VSMAP=OFF \
 	-DENGINE_CMAP=OFF \
+	-DENGINE_CSMAP=OFF \
 	-DENGINE_VCMAP=OFF \
 	-DENGINE_CACHING=OFF \
 	-DENGINE_STREE=OFF \
@@ -53,7 +51,7 @@ make -j$(nproc)
 make -j$(nproc) install
 
 #
-# 2) RUBY dependencies - all of the dependencies (gems) needed to run
+# RUBY dependencies - all of the dependencies (gems) needed to run
 #                        pmemkv-ruby will be saved
 #                        in the /opt/bindings/ruby directory
 cd $WORKDIR
@@ -68,17 +66,7 @@ bundle package
 mv -v vendor/cache/* /opt/bindings/ruby/
 
 #
-# 3) Build and install JNI
-#
-cd $WORKDIR
-git clone https://github.com/pmem/pmemkv-jni.git
-cd pmemkv-jni
-git checkout $JNI_VERSION
-make test
-make install prefix=$PREFIX
-
-#
-# 4) JAVA dependencies - all of the dependencies needed to run
+# JAVA dependencies - all of the dependencies needed to run
 #                        pmemkv-java will be saved
 #                        in the /opt/bindings/java directory
 cd $WORKDIR
@@ -87,12 +75,13 @@ mkdir -p /opt/bindings/java/
 git clone https://github.com/pmem/pmemkv-java.git
 cd pmemkv-java
 git checkout $JAVA_VERSION
+mvn install -Dmaven.test.skip=true
 mvn dependency:go-offline
-mvn install
+rm -r ~/.m2/repository/io/pmem
 mv -v ~/.m2/repository /opt/bindings/java/
 
 #
-# 5) NodeJS dependencies - all of the dependencies needed to run
+# NodeJS dependencies - all of the dependencies needed to run
 #                          pmemkv-nodejs will be saved
 #                          in the /opt/bindings/nodejs/ directory
 cd $WORKDIR
@@ -109,14 +98,11 @@ cp -rv ./node_modules /opt/bindings/nodejs/
 cd $WORKDIR/pmemkv/build
 make uninstall
 
-cd $WORKDIR/pmemkv-jni
-make uninstall
-
 cd $WORKDIR/pmemkv-nodejs
 npm uninstall
 
 cd $WORKDIR
-rm -r pmemkv pmemkv-ruby pmemkv-jni pmemkv-java pmemkv-nodejs
+rm -r pmemkv pmemkv-ruby pmemkv-java pmemkv-nodejs
 
 
 # make the /opt/bindings directory world-readable

--- a/utils/docker/run-bindings.sh
+++ b/utils/docker/run-bindings.sh
@@ -55,7 +55,7 @@ cd pmemkv-java
 git checkout $JAVA_VERSION
 mkdir -p ~/.m2/repository
 cp -r /opt/bindings/java/repository ~/.m2/
-mvn --offline install
+mvn install
 
 echo
 echo "####################################################################"

--- a/utils/docker/run-bindings.sh
+++ b/utils/docker/run-bindings.sh
@@ -13,11 +13,8 @@ source `dirname $0`/prepare-for-build.sh
 # master: Merge pull request #44 from lukaszstolarczuk/update-tra..., 21.11.2019
 RUBY_VERSION="3741e3df698245fc8a15822a1aa85b5c211fd332"
 
-# master: Merge pull request #34 from igchor/add_pmemkv_errormsg, 06.12.2020
-JNI_VERSION="fcc8370b230ab3236d062a121e22dcebf37b90ec"
-
-# master: Merge pull request #38 from lukaszstolarczuk/update-tra..., 17.03.2020
-JAVA_VERSION="ab8747c3baf4af8cd2ce1985986d7fcc241ccd65"
+# stable-1.0: Merge pull request #86 from lukaszstolarczuk/remov..., 19.08.2020
+JAVA_VERSION="e210e6490092d5aa8afbcc49e504d917f140448a"
 
 # master: Merge pull request #49 from how759/buffer-arguments, 02.03.2020
 NODEJS_VERSION="12ecc0a9c3205425bf0aa1767eada53834535045"
@@ -47,18 +44,6 @@ mkdir -p vendor/cache/
 cp -r /opt/bindings/ruby/* vendor/cache/
 bundle install --local
 bundle exec rspec
-
-echo
-echo "#################################################################"
-echo "### Verifying building and installing of the pmemkv-jni bindings "
-echo "#################################################################"
-cd ~
-git clone https://github.com/pmem/pmemkv-jni.git
-cd pmemkv-jni
-git checkout $JNI_VERSION
-
-make test
-sudo_password -S make install prefix=$PREFIX
 
 echo
 echo "##################################################################"


### PR DESCRIPTION
and adjust binding's building scripts (based on commits on master: ea84f4a & 1ddc4f6).


This PR is needed, because stable-1.2 is failing on bindings' checks (e.g. #765). We'll have Java updated to stable-1.0 version (on pmemkv's stable-1.2 branch).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/776)
<!-- Reviewable:end -->
