### PR TITLE
treat doxygen warnings as errors

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -80,6 +80,12 @@ endif()
 # prepare C++ documentation (using doxygen format)
 include(FindDoxygen)
 if(DOXYGEN_FOUND AND DOXYGEN_DOT_FOUND)
+	if(DEVELOPER_MODE)
+		set(DOXYGEN_WARN_AS_ERROR "YES")
+	else()
+		set(DOXYGEN_WARN_AS_ERROR "NO")
+	endif()
+
 	configure_file("${CMAKE_CURRENT_SOURCE_DIR}/libpmemkv.Doxyfile.in"
 		"${CMAKE_CURRENT_BINARY_DIR}/libpmemkv.Doxyfile" @ONLY)
 	install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/cpp_html/ DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/doc/libpmemkv.Doxyfile.in
+++ b/doc/libpmemkv.Doxyfile.in
@@ -224,3 +224,5 @@ HTML_TIMESTAMP = NO
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED = __cpp_lib_uncaught_exceptions _WIN32
+
+WARN_AS_ERROR = @DOXYGEN_WARN_AS_ERROR@


### PR DESCRIPTION
treat doxygen warnings as errors like in libpmemobjcpp

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/777)
<!-- Reviewable:end -->
