### PR TITLE
Fix other OSes

### DIFF
--- a/.github/workflows/other_OSes.yml
+++ b/.github/workflows/other_OSes.yml
@@ -2,9 +2,8 @@
 name: pmemkv-other
 on:
   schedule:
-    # run this job at 01:00 UTC everyday
-    # XXX: when checked it works properly, change to e.g. "every Monday"
-    - cron:  '0 1 * * *'
+    # run this job at 01:00 UTC every second day
+    - cron:  '0 1 */2 * *'
 
 env:
   REPO:           pmemkv
@@ -18,18 +17,17 @@ jobs:
     env:
       HOST_WORKDIR:   /home/runner/work/pmemkv/pmemkv
       WORKDIR:        utils/docker
+      TYPE:           debug
     strategy:
       matrix:
-        CONFIG: ["TYPE=debug OS=centos OS_VER=8",
-                 # Arch. fails because of: https://github.com/memkind/memkind/issues/317
-                 # "TYPE=debug OS=archlinux-base OS_VER=latest"
-                 "TYPE=debug OS=debian OS_VER=testing",
-                 "TYPE=debug OS=debian OS_VER=unstable",
-                 # Fed. rawhide fails because of: https://github.com/pmem/pmdk/issues/4938
-                 # "TYPE=debug OS=fedora OS_VER=rawhide",
-                 "TYPE=debug OS=opensuse-leap OS_VER=latest",
-                 "TYPE=debug OS=opensuse-tumbleweed OS_VER=latest",
-                 "TYPE=debug OS=ubuntu OS_VER=rolling"]
+        CONFIG: ["OS=centos OS_VER=8",
+                 "OS=archlinux-base OS_VER=latest",
+                 "OS=debian OS_VER=testing",
+                 "OS=debian OS_VER=unstable",
+                 "OS=fedora OS_VER=rawhide",
+                 "OS=opensuse-leap OS_VER=latest",
+                 "OS=opensuse-tumbleweed OS_VER=latest",
+                 "OS=ubuntu OS_VER=rolling"]
     steps:
        - name: Print out the current date and time
          run: date

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -76,7 +76,7 @@ RUN ./install-libpmemobj-cpp.sh RPM
 
 # Install memkind
 COPY install-memkind.sh install-memkind.sh
-RUN ./install-memkind.sh centos
+RUN ./install-memkind.sh
 
 # Add user
 ENV USER user

--- a/utils/docker/images/Dockerfile.centos-8
+++ b/utils/docker/images/Dockerfile.centos-8
@@ -27,8 +27,7 @@ RUN dnf install -y 'dnf-command(config-manager)'
 RUN dnf config-manager --set-enabled PowerTools
 
 # Install basic tools
-RUN dnf update -y \
- && dnf install -y \
+RUN dnf install -y \
 	autoconf \
 	automake \
 	clang \

--- a/utils/docker/images/Dockerfile.fedora-rawhide
+++ b/utils/docker/images/Dockerfile.fedora-rawhide
@@ -62,13 +62,14 @@ RUN dnf debuginfo-install -y glibc
 COPY install-valgrind.sh install-valgrind.sh
 RUN ./install-valgrind.sh
 
-# Install pmdk
+# Install pmdk from sources, because of:
+# https://github.com/pmem/pmdk/issues/4938
 COPY install-pmdk.sh install-pmdk.sh
-RUN ./install-pmdk.sh rpm
+RUN ./install-pmdk.sh
 
-# Install pmdk c++ bindings
+# Install pmdk c++ bindings (also from sources)
 COPY install-libpmemobj-cpp.sh install-libpmemobj-cpp.sh
-RUN ./install-libpmemobj-cpp.sh RPM
+RUN ./install-libpmemobj-cpp.sh
 
 # Add user
 ENV USER user

--- a/utils/docker/images/install-memkind.sh
+++ b/utils/docker/images/install-memkind.sh
@@ -3,36 +3,34 @@
 # Copyright 2019-2020, Intel Corporation
 
 #
-# install-memkind.sh <OS> - installs memkind from sources; depends on
+# install-memkind.sh - installs memkind from sources; depends on
 #		the system it uses proper installation paramaters
 #
 
 set -e
 
-OS=$1
-
-# v1.10.0, contains new libmemkind namespace
+# v1.10.1, contains new libmemkind namespace
 MEMKIND_VERSION=v1.10.1
 
 WORKDIR=$(pwd)
 
 git clone https://github.com/memkind/memkind
-cd $WORKDIR/memkind
-git checkout $MEMKIND_VERSION
+cd ${WORKDIR}/memkind
+git checkout ${MEMKIND_VERSION}
 
-# set OS-specific configure options
+echo "set OS-specific configure options"
 OS_SPECIFIC=""
-case $(echo $OS | cut -d'-' -f1) in
+case $(echo ${OS} | cut -d'-' -f1) in
 	centos|opensuse)
 		OS_SPECIFIC="--libdir=/usr/lib64"
 		;;
 esac
 
 ./autogen.sh
-./configure --prefix=/usr $OS_SPECIFIC
+./configure --prefix=/usr ${OS_SPECIFIC}
 make -j$(nproc)
 make -j$(nproc) install
 
-# cleanup
-cd $WORKDIR
+echo "cleanup:"
+cd ${WORKDIR}
 rm -r memkind


### PR DESCRIPTION
and clean `install-memkind.sh` a bit (from unneeded parameter).

It was tested [on GHA](https://github.com/pmem/pmemkv/actions/runs/270471363) - all OSes worked fine.


- [x] last commit to be dropped
- [x] wait until cpp_check_style will be done only on Ubuntu (it's delivered into stable branch)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/781)
<!-- Reviewable:end -->
