### PR TITLE
Update CMake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2017-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv)
 
 include(cmake/helpers.cmake)

--- a/examples/pmemkv_basic_c/CMakeLists.txt
+++ b/examples/pmemkv_basic_c/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv_basic C)
 
 find_package(PkgConfig QUIET)

--- a/examples/pmemkv_basic_cpp/CMakeLists.txt
+++ b/examples/pmemkv_basic_cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv_basic CXX)
 
 find_package(PkgConfig QUIET)

--- a/examples/pmemkv_comparator_c/CMakeLists.txt
+++ b/examples/pmemkv_comparator_c/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv_basic CXX)
 
 find_package(PkgConfig QUIET)

--- a/examples/pmemkv_comparator_c/CMakeLists.txt
+++ b/examples/pmemkv_comparator_c/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2020, Intel Corporation
 
 cmake_minimum_required(VERSION 3.3)
-project(pmemkv_basic CXX)
+project(pmemkv_basic C)
 
 find_package(PkgConfig QUIET)
 if(PKG_CONFIG_FOUND)

--- a/examples/pmemkv_comparator_cpp/CMakeLists.txt
+++ b/examples/pmemkv_comparator_cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv_basic CXX)
 
 find_package(PkgConfig QUIET)

--- a/examples/pmemkv_config_c/CMakeLists.txt
+++ b/examples/pmemkv_config_c/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv_config C)
 
 find_package(PkgConfig QUIET)

--- a/examples/pmemkv_open_cpp/CMakeLists.txt
+++ b/examples/pmemkv_open_cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019, Intel Corporation
+# Copyright 2019-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv_open_cpp CXX)
 
 find_package(PkgConfig QUIET)

--- a/examples/pmemkv_pmemobj_cpp/CMakeLists.txt
+++ b/examples/pmemkv_pmemobj_cpp/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright 2019-2020, Intel Corporation
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.3)
 project(pmemkv_pmemobj CXX)
 
 set(LIBPMEMOBJ_CPP_REQUIRED_VERSION 1.9)

--- a/tests/compatibility/CMakeLists.txt
+++ b/tests/compatibility/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 project(pmemkv_compatibility_test)
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.13)
 
 include(../ctest_helpers.cmake)
 


### PR DESCRIPTION
- set min required version to lower values than there were (for top-level and examples' CMake) - it's arbitrarily set to 3.3,
- fix comparator's example project's language,
- set compatibility test's CMake to higher value of min cmake required version (3.13) - it uses 'target_link_directories'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/808)
<!-- Reviewable:end -->
