### PR TITLE
remove wrapper structures for pmem::obj::string

### DIFF
--- a/src/engines-experimental/csmap.h
+++ b/src/engines-experimental/csmap.h
@@ -23,14 +23,7 @@ namespace internal
 namespace csmap
 {
 
-struct key_type : public pmem::obj::string {
-	key_type() = default;
-	key_type(const key_type &) = default;
-	key_type(key_type &&) = default;
-	key_type(string_view str) : pmem::obj::string(str.data(), str.size())
-	{
-	}
-};
+using key_type = pmem::obj::string;
 
 static_assert(sizeof(key_type) == 32, "");
 

--- a/src/engines-experimental/stree.h
+++ b/src/engines-experimental/stree.h
@@ -29,22 +29,7 @@ namespace stree
  */
 const size_t DEGREE = 32;
 
-struct string_t : public pmem::obj::string {
-	string_t() = default;
-	string_t(const string_t &) = default;
-	string_t(string_t &&) = default;
-	string_t(string_view str) : pmem::obj::string(str.data(), str.size())
-	{
-	}
-	pmem::obj::string &operator=(const string_view &other)
-	{
-		return pmem::obj::string::assign(other.data(), other.size());
-	}
-	pmem::obj::string &operator=(const string_t &other)
-	{
-		return pmem::obj::string::assign(other.data(), other.size());
-	}
-};
+using string_t = pmem::obj::string;
 
 using key_type = string_t;
 using value_type = string_t;

--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -18,8 +18,8 @@ PREFIX="/usr"
 PACKAGE_TYPE=${1^^} #To uppercase
 echo "PACKAGE_TYPE: ${PACKAGE_TYPE}"
 
-# 1.11; 30.09.2020
-LIBPMEMOBJ_CPP_VERSION="1.11"
+# Merge pull request #927 from JanDorniak99/range_method_basic_string; 13.10.2020
+LIBPMEMOBJ_CPP_VERSION="216012ae7beca8223c43c56b4d0288eec6c3a179"
 echo "LIBPMEMOBJ_CPP_VERSION: ${LIBPMEMOBJ_CPP_VERSION}"
 
 build_dir=$(mktemp -d -t libpmemobj-cpp-XXX)


### PR DESCRIPTION
This PR have following:

- docker_images: update libpmemobj++ installation script
- csmap: remove unnecessary key structure

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/822)
<!-- Reviewable:end -->
