### PR TITLE
get rid of reading subconfig from json config

### DIFF
--- a/doc/libpmemkv_json_config.3.md
+++ b/doc/libpmemkv_json_config.3.md
@@ -47,7 +47,6 @@ pmemkv_json_config is a helper library that provides two functions:
 	in JSON strings and their corresponding types in pmemkv_config are:
 	+ **number** -- int64 or uint64
 	+ **string** -- const char *
-	+ **object** -- (another JSON string) -> pointer to pmemkv_config (can be obtained using pmemkv_config_get_object)
 	+ **True**, **False** -- int64
 
 `const char *pmemkv_config_from_json_errormsg(void);`

--- a/examples/pmemkv_config_c/pmemkv_config.c
+++ b/examples/pmemkv_config_c/pmemkv_config.c
@@ -73,10 +73,7 @@ int main()
 
 	/* Parse JSON and put all items found into config_from_json */
 	status = pmemkv_config_from_json(config_from_json, "{\"path\":\"/dev/shm\",\
-		 \"size\":1073741824,\
-		 \"subconfig\":{\
-			\"size\":1073741824\
-			}\
+		 \"size\":1073741824\
 		}");
 	ASSERT(status == PMEMKV_STATUS_OK);
 
@@ -84,18 +81,6 @@ int main()
 	status = pmemkv_config_get_string(config_from_json, "path", &path);
 	ASSERT(status == PMEMKV_STATUS_OK);
 	ASSERT(strcmp(path, "/dev/shm") == 0);
-
-	pmemkv_config *subconfig;
-
-	/* Get pointer to nested configuration "subconfig" */
-	status = pmemkv_config_get_object(config_from_json, "subconfig",
-					  (void **)&subconfig);
-	ASSERT(status == PMEMKV_STATUS_OK);
-
-	size_t sub_size;
-	status = pmemkv_config_get_uint64(subconfig, "size", &sub_size);
-	ASSERT(status == PMEMKV_STATUS_OK);
-	ASSERT(sub_size == 1073741824);
 
 	pmemkv_config_delete(config_from_json);
 

--- a/src/libpmemkv_json_config.cc
+++ b/src/libpmemkv_json_config.cc
@@ -47,32 +47,6 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 				if (status != PMEMKV_STATUS_OK)
 					throw std::runtime_error(
 						"Inserting bool to the config failed");
-			} else if (itr->value.IsObject()) {
-				rapidjson::StringBuffer sb;
-				rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
-				itr->value.Accept(writer);
-
-				auto sub_cfg = pmemkv_config_new();
-
-				if (sub_cfg == nullptr) {
-					ERR() << "Cannot allocate subconfig";
-					return PMEMKV_STATUS_OUT_OF_MEMORY;
-				}
-
-				auto status =
-					pmemkv_config_from_json(sub_cfg, sb.GetString());
-				if (status != PMEMKV_STATUS_OK) {
-					pmemkv_config_delete(sub_cfg);
-					throw std::runtime_error(
-						"Cannot parse subconfig");
-				}
-
-				status = pmemkv_config_put_object(
-					config, itr->name.GetString(), sub_cfg,
-					(void (*)(void *)) & pmemkv_config_delete);
-				if (status != PMEMKV_STATUS_OK)
-					throw std::runtime_error(
-						"Inserting a new entry to the config failed");
 			} else {
 				static std::string kTypeNames[] = {
 					"Null",	 "False",  "True",  "Object",

--- a/tests/config/json_to_config.cc
+++ b/tests/config/json_to_config.cc
@@ -21,7 +21,7 @@ static void simple_test()
 
 	auto ret = pmemkv_config_from_json(
 		config, "{\"string\": \"abc\", \"int\": 123, \"bool\": true}");
-	// XXX: extend by adding "false", subconfig, negative value
+	// XXX: extend by adding "false", negative value
 	UT_ASSERTeq(ret, PMEMKV_STATUS_OK);
 
 	const char *value_string;


### PR DESCRIPTION
since caching engine is not here it's not needed anymore.

ref. #790

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/828)
<!-- Reviewable:end -->
