### PR TITLE
add "rebuild" param to utils' script, to force dockers rebuilding

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -42,7 +42,7 @@ jobs:
             fetch-depth: 50
 
        - name: Pull or rebuild the image
-         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh
+         run: cd $WORKDIR && ${{ matrix.CONFIG }} ./pull-or-rebuild-image.sh rebuild
 
        - name: Run the build
          run: cd $WORKDIR && ${{ matrix.CONFIG }} ./build.sh

--- a/travis.yml
+++ b/travis.yml
@@ -26,7 +26,7 @@ before_install:
   - echo $TRAVIS_COMMIT_RANGE
   - export HOST_WORKDIR=`pwd`
   - cd utils/docker
-  - ./pull-or-rebuild-image.sh
+  - ./pull-or-rebuild-image.sh rebuild
 
 script:
   - ./build.sh

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -34,9 +34,10 @@
 # pull-or-rebuild-image.sh - rebuilds the Docker image used in the
 #                            current Travis build if necessary.
 #
-# The script rebuilds the Docker image if the Dockerfile for the current
-# OS version (Dockerfile.${OS}-${OS_VER}) or any .sh script from the directory
-# with Dockerfiles were modified and committed.
+# The script rebuilds the Docker image if:
+# 1. the Dockerfile for the current OS version (Dockerfile.${OS}-${OS_VER})
+#    or any .sh script in the Dockerfiles directory were modified and committed, or
+# 2. "rebuild" param was passed as first argument to this script.
 #
 # If the Travis build is not of the "pull_request" type (i.e. in case of
 # merge after pull_request) and it succeed, the Docker image should be pushed
@@ -78,6 +79,18 @@ if [[ -z "$HOST_WORKDIR" ]]; then
 	exit 1
 fi
 
+# Path to directory with Dockerfiles and image building scripts
+images_dir_name=images
+base_dir=utils/docker/$images_dir_name
+
+# If "rebuild" param is passed to script, force rebuild
+if [[ "$1" == "rebuild" ]]; then
+	pushd $images_dir_name
+	./build-image.sh ${OS}-${OS_VER}
+	popd
+	exit 0
+fi
+
 # Find all the commits for the current build
 if [ -n "$CI_COMMIT_RANGE" ]; then
 	commits=$(git rev-list $CI_COMMIT_RANGE)
@@ -93,10 +106,6 @@ files=$(for commit in $commits; do git diff-tree --no-commit-id --name-only \
 	-r $commit; done | sort -u)
 echo "Files modified within the commit range:"
 for file in $files; do echo $file; done
-
-# Path to directory with Dockerfiles and image building scripts
-images_dir_name=images
-base_dir=utils/docker/$images_dir_name
 
 # Check if committed file modifications require the Docker image to be rebuilt
 for file in $files; do


### PR DESCRIPTION
it makes more sense to rebuild dockers all the time on stable branches,
because we don't have to count on DockerHub's policy to keep our
docker images on their servers.

this change is based on master's commit: ec8a01f8957790fbb10d1699e3b1e2cb03b9ebcb

This is similar approach to https://github.com/pmem/libpmemobj-cpp/pull/929

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/835)
<!-- Reviewable:end -->
