### PR TITLE
CI: don't use github.repository variable

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -8,7 +8,7 @@ on:
 env:
   REPO:           pmemkv
   GITHUB_REPO:    pmem/pmemkv
-  CONTAINER_REG:  ghcr.io/${{github.repository}}
+  CONTAINER_REG:  ghcr.io/pmem/pmemkv
 
 jobs:
   linux:

--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   REPO:           pmemkv
   GITHUB_REPO:    pmem/pmemkv
-  CONTAINER_REG:  ghcr.io/${{github.repository}}
+  CONTAINER_REG:  ghcr.io/pmem/pmemkv
 
 jobs:
   linux:

--- a/.github/workflows/other_OSes.yml
+++ b/.github/workflows/other_OSes.yml
@@ -8,7 +8,7 @@ on:
 env:
   REPO:           pmemkv
   GITHUB_REPO:    pmem/pmemkv
-  CONTAINER_REG:  ghcr.io/${{github.repository}}
+  CONTAINER_REG:  ghcr.io/pmem/pmemkv
 
 jobs:
   linux:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -212,12 +212,15 @@ the repository has to be properly configured.
   which will be target to make an automatic pull request with documentation.
   In most cases it will be the same as Github account name.
 
-To enable automatic images pushing to Github Container Registry, following variables has to be set up:
+To enable automatic images pushing to Github Container Registry, following variables:
 
-* `GH_CR_USER` secret variable. An account (with proper permissions) to publish images to
-  the Container Registry (tab **Packages** in your GH profile/organization).
+* `CONTAINER_REG` existing environment variable (defined in workflow files, in .github/ directory)
+  has to be updated to contain proper GitHub Container Registry address (to forking user's container registry),
 
-* `GH_CR_PAT` secret variable. Personal Access Token (with only read & write packages
-  permissions), to be generated as described
+* `GH_CR_USER` secret variable has to be set up - an account (with proper permissions) to publish
+  images to the Container Registry (tab **Packages** in your GH profile/organization).
+
+* `GH_CR_PAT` secret variable also has to be set up - Personal Access Token
+  (with only read & write packages permissions), to be generated as described
   [here](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token#creating-a-token)
   for selected account (user defined in above variable).


### PR DESCRIPTION
it breaks builds on forked repos. Update CONTRIBUTING.md with
information how to properly setup publishing images on forked repos.

- [ ] wait for https://github.com/pmem/libpmemobj-cpp/pull/976 to be merged first, to see if this change is proper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/841)
<!-- Reviewable:end -->
