### PR TITLE
cmake: update finding TBB package

### DIFF
--- a/cmake/tbb.cmake
+++ b/cmake/tbb.cmake
@@ -1,23 +1,24 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2017-2019, Intel Corporation
+# Copyright 2017-2020, Intel Corporation
+
+message(STATUS "Checking for module 'tbb'")
 
 if(PKG_CONFIG_FOUND)
-	pkg_check_modules(TBB tbb)
+	pkg_check_modules(TBB QUIET tbb)
 endif()
 
+# Now, if needed, try to find it without pkg-config. 'find_package' way will work
+# most likely just only for testing and development, not when linking with an actual app.
 if(NOT TBB_FOUND)
 	# find_package without unsetting this var is not working correctly
 	unset(TBB_FOUND CACHE)
-	find_package(TBB COMPONENTS tbb)
 
-	if(TBB_FOUND)
-		message(STATUS "TBB package found without pkg-config")
-	endif()
-
+	find_package(TBB REQUIRED tbb)
 	set(TBB_LIBRARIES ${TBB_IMPORTED_TARGETS})
-endif()
 
-if(NOT TBB_FOUND)
-	message(FATAL_ERROR "TBB not found. Please set TBB_DIR CMake variable if TBB \
-is installed in a non-standard directory, like: -DTBB_DIR=<path_to_tbb_cmake_dir>")
+	message(STATUS "  Found in: ${TBB_DIR} (ver: ${TBB_VERSION})")
+	message(WARNING "TBB package found without pkg-config. If you'll compile a standalone "
+		"application and link with this libpmemkv, TBB may not be properly linked!")
+else()
+	message(STATUS "  Found in: ${TBB_LIBDIR} using pkg-config (ver: ${TBB_VERSION})")
 endif()


### PR DESCRIPTION
- print more concise messages,
- add warning when found without pkg-config,
- make it required (find_package gives very robust description
  how to properly find it).

I've tested it on my ubuntu 20.04 - with pkg-config, without it and without tbb at all.