### PR TITLE
docker: push image on forced rebuild

### DIFF
--- a/utils/docker/images/push-image.sh
+++ b/utils/docker/images/push-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2020, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -68,5 +68,5 @@ fi
 # Log in to the Docker Hub
 docker login -u="$DOCKERHUB_USER" -p="$DOCKERHUB_PASSWORD"
 
-# Push the image to the repository
+echo "Push the image to the repository"
 docker push ${DOCKERHUB_REPO}:${TAG}

--- a/utils/docker/pull-or-rebuild-image.sh
+++ b/utils/docker/pull-or-rebuild-image.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2016-2020, Intel Corporation
+# Copyright 2016-2021, Intel Corporation
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -88,6 +88,18 @@ if [[ "$1" == "rebuild" ]]; then
 	pushd $images_dir_name
 	./build-image.sh ${OS}-${OS_VER}
 	popd
+
+	if [[ "$CI_REPO_SLUG" == "$GITHUB_REPO" \
+		&& ($CI_BRANCH == stable-* || $CI_BRANCH == master) \
+		&& $CI_EVENT_TYPE != "pull_request" \
+		&& $PUSH_IMAGE == "1" ]]
+	then
+		echo "The image will be pushed to Docker Hub"
+		touch $CI_FILE_PUSH_IMAGE_TO_REPO
+	else
+		echo "Skip pushing the image to Docker Hub"
+	fi
+
 	exit 0
 fi
 


### PR DESCRIPTION

fix for stable branches, where forced "rebuild" param was provided and the images were not pushed into container registry

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/909)
<!-- Reviewable:end -->
