### PR TITLE
ignore setcontext memcheck (PPC)

### DIFF
--- a/tests/memcheck-libunwind.supp
+++ b/tests/memcheck-libunwind.supp
@@ -29,3 +29,9 @@
    obj:*libunwind*
    ...
 }
+{
+   libunwind calls glibc's setcontext on some architectures, e.g. ppc
+   Memcheck:Addr8
+   fun:setcontext*
+   ...
+}


### PR DESCRIPTION
The fix from obj-cpp applies without modifications.

Fixes #918 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/919)
<!-- Reviewable:end -->
