### PR TITLE
Fix for errormsg on NOT_FOUND

### DIFF
--- a/src/out.cc
+++ b/src/out.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Intel Corporation
+ * Copyright 2019-2021, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -32,11 +32,14 @@
 
 #include "out.h"
 
+#include "libpmemkv.h"
+
 #include <sstream>
 #include <string>
 
 static thread_local std::stringstream error_stream;
 static thread_local std::string str;
+static thread_local int last_status;
 
 std::ostream &out_err_stream(const char *func)
 {
@@ -47,8 +50,16 @@ std::ostream &out_err_stream(const char *func)
 	return error_stream;
 }
 
+void set_last_status(int s)
+{
+	last_status = s;
+}
+
 const char *out_get_errormsg(void)
 {
+	if (last_status == PMEMKV_STATUS_NOT_FOUND ||
+	    last_status == PMEMKV_STATUS_STOPPED_BY_CB)
+		return "";
 	str = error_stream.str();
 	return str.c_str();
 }

--- a/src/out.h
+++ b/src/out.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019, Intel Corporation
+ * Copyright 2019-2021, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,5 +47,6 @@ std::ostream &out_err_stream(const char *func);
 #define ERR() out_err_stream(__func__)
 
 const char *out_get_errormsg(void);
+void set_last_status(int status);
 
 #endif /* LIBPMEMKV_OUT_H */

--- a/tests/engines/blackhole_test.cc
+++ b/tests/engines/blackhole_test.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020, Intel Corporation
+ * Copyright 2017-2021, Intel Corporation
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -171,4 +171,29 @@ TEST_F(BlackholeTest, ErrormsgTest)
 
 	/* Test whether errormsg is cleared correctly after each error */
 	ASSERT_TRUE(pmem::kv::errormsg() == err);
+}
+
+TEST_F(BlackholeTest, ErrormsgClearedTest)
+{
+	auto s = kv.open("non-existing name");
+	ASSERT_TRUE(s == pmem::kv::status::WRONG_ENGINE_NAME);
+
+	auto err = pmem::kv::errormsg();
+	ASSERT_TRUE(err.size() > 0);
+
+	ASSERT_TRUE(pmem::kv::errormsg() == err);
+
+	s = kv.open("blackhole");
+	ASSERT_TRUE(s == pmem::kv::status::OK);
+
+	std::string value;
+	s = kv.get("Nonexisting key:", &value);
+	ASSERT_TRUE(s == pmem::kv::status::NOT_FOUND);
+	err = pmem::kv::errormsg();
+	ASSERT_TRUE(err == "");
+
+	s = kv.open("non-existing name");
+	ASSERT_TRUE(s == pmem::kv::status::WRONG_ENGINE_NAME);
+	err = pmem::kv::errormsg();
+	ASSERT_TRUE(err.size() > 0);
 }


### PR DESCRIPTION
NOT_FOUND and STOPPED_BY_CB are not errors,
and do not set error message so, last status (per thread) have to be tracked, to
avoid printing status from previous error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/923)
<!-- Reviewable:end -->
