### PR TITLE
error_msg_cleared test backport

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019-2020, Intel Corporation
+# Copyright 2019-2021, Intel Corporation
 
 include(ctest_helpers.cmake)
 
@@ -69,6 +69,9 @@ endif()
 ## Common tests
 build_test(wrong_engine_name_test wrong_engine_name_test.cc)
 add_test_generic(NAME wrong_engine_name_test TRACERS none)
+
+build_test(error_msg_test error_msg_test.cc)
+add_test_generic(NAME error_msg_test TRACERS none)
 
 if(BUILD_EXAMPLES AND ENGINE_CMAP)
 	add_dependencies(tests example-pmemkv_basic_c

--- a/tests/error_msg_test.cc
+++ b/tests/error_msg_test.cc
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/* Copyright 2021, Intel Corporation */
+
+#include <libpmemkv.hpp>
+
+#include "unittest.hpp"
+
+static void errormsg_cleared()
+{
+	pmem::kv::db kv;
+	auto s = kv.open("non-existing name");
+	UT_ASSERT(s == pmem::kv::status::WRONG_ENGINE_NAME);
+
+	auto err = pmem::kv::errormsg();
+	UT_ASSERT(err.size() > 0);
+
+	s = kv.open("blackhole");
+	UT_ASSERT(s == pmem::kv::status::OK);
+
+	std::string value;
+	s = kv.get("Nonexisting key:", &value);
+	UT_ASSERT(s == pmem::kv::status::NOT_FOUND);
+	err = pmem::kv::errormsg();
+	UT_ASSERT(err == "");
+	UT_ASSERTeq(err.size(), 0);
+
+	s = kv.open("non-existing name");
+	UT_ASSERT(s == pmem::kv::status::WRONG_ENGINE_NAME);
+	err = pmem::kv::errormsg();
+	UT_ASSERT(err.size() > 0);
+}
+
+int main()
+{
+	errormsg_cleared();
+
+	return 0;
+}


### PR DESCRIPTION
Test scenario is based on issue in pmemkv-java binding
https://github.com/pmem/pmemkv-java/issues/113

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/925)
<!-- Reviewable:end -->
