### PR TITLE
utils: make sure hub command is available

### DIFF
--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -95,7 +95,10 @@ git add -A
 git commit -m "doc: automatic gh-pages docs update" && true
 git push -f ${ORIGIN} ${GH_PAGES_NAME}
 
-# Makes pull request.
+echo "Make sure hub command is available:"
+hub --version
+
+echo "Make or update pull request:"
 # When there is already an open PR or there are no changes an error is thrown, which we ignore.
 hub pull-request -f -b ${DOC_REPO_OWNER}:gh-pages -h ${BOT_NAME}:${GH_PAGES_NAME} \
 	-m "doc: automatic gh-pages docs update" && true


### PR DESCRIPTION
when preparing PR with docs.
It may fail in some near future, since hub package is out of Fedora Rawhide distribution (see: https://github.com/pmem/libpmemobj-cpp/issues/1013 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/947)
<!-- Reviewable:end -->
