### PR TITLE
cmake: change default CMAKE_BUILD_TYPE to RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD ${CXX_STANDARD})
 
 # Specify and print the build type
-if(EXISTS "${PMEMKV_ROOT_DIR}/.git")
-	# current sources were downloaded using git, so we assume it's for debug (developing) purposes
-	set(DEFAULT_BUILD_TYPE "Debug")
-else()
-	set(DEFAULT_BUILD_TYPE "RelWithDebInfo")
-endif()
+set(DEFAULT_BUILD_TYPE "RelWithDebInfo")
 set(predefined_build_types
 	Debug
 	Release

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,12 @@ XXX Igor Chorążewicz <igor.chorazewicz@intel.com>
 	Major fixes:
 	-
 
+	Other changes:
+	- Switched default CMake's build type from "Debug" to "RelWithDebInfo"
+		when compiling from sources - it's relevant for a GitHub users
+		(who may e.g. run some benchmarks)
+	-
+
 Mon Feb 15 2021 Igor Chorążewicz <igor.chorazewicz@intel.com>
 
 	* Version 1.4

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -43,9 +43,9 @@ git clone https://github.com/pmem/pmemkv
 cd pmemkv
 mkdir ./build
 cd ./build
-cmake .. -DBUILD_TESTS=ON   # run CMake
-make -j$(nproc)             # build everything
-make test                   # run all tests
+cmake .. -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug		# run CMake, prepare Debug version
+make -j$(nproc)					# build everything
+make test						# run all tests
 ```
 
 Instead of the last command (`make test`) you can run
@@ -75,15 +75,16 @@ cmake ..
 To package `pmemkv` as a shared library and install on your system:
 
 ```sh
-sudo make install		# install shared library to the default location: /usr/local
-sudo make uninstall		# remove shared library and headers
+cmake .. [-DCMAKE_BUILD_TYPE=Release]	# prepare e.g. Release version
+sudo make install			# install shared library to the default location: /usr/local
+sudo make uninstall			# remove shared library and headers
 ```
 
 To install this library into other locations, pass appropriate value to cmake
 using CMAKE_INSTALL_PREFIX variable like this:
 
 ```sh
-cmake .. -DCMAKE_INSTALL_PREFIX=/usr
+cmake .. -DCMAKE_INSTALL_PREFIX=/usr [-DCMAKE_BUILD_TYPE=Release]
 sudo make install		# install to path specified by CMAKE_INSTALL_PREFIX
 sudo make uninstall		# remove shared library and headers from path specified by CMAKE_INSTALL_PREFIX
 ```
@@ -230,7 +231,7 @@ engine in [ENGINES-experimental.md](doc/ENGINES-experimental.md).
 
 ```sh
 ...
-cmake .. -DCPACK_GENERATOR="$GEN" -DCMAKE_INSTALL_PREFIX=/usr
+cmake .. -DCPACK_GENERATOR="$GEN" -DCMAKE_INSTALL_PREFIX=/usr [-DCMAKE_BUILD_TYPE=Release]
 make -j$(nproc) package
 ```
 


### PR DESCRIPTION
when compiling froum sources (e.g. cloned from GitHub). In the past some users
run e.g. benchmarks and was surprised with the results. Using release version
should avoid that problem. Documentation is updated as well to point users
with proper CMake parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/948)
<!-- Reviewable:end -->
