### PR TITLE
Fix GHA Ubuntu 20.04 and cpp installation script

### DIFF
--- a/.github/workflows/gha.yml
+++ b/.github/workflows/gha.yml
@@ -23,10 +23,10 @@ jobs:
     strategy:
       matrix:
         CONFIG: ["TYPE=debug OS=fedora OS_VER=32",
-                 "TYPE=debug OS=ubuntu OS_VER=20.10 PUSH_IMAGE=1",
+                 "TYPE=debug OS=ubuntu OS_VER=20.10",
                  "TYPE=debug OS=ubuntu OS_VER=20.04 CHECK_CPP_STYLE=1 COVERAGE=1",
                  "TYPE=release OS=fedora OS_VER=32",
-                 "TYPE=release OS=ubuntu OS_VER=20.04",
+                 "TYPE=release OS=ubuntu OS_VER=20.04 PUSH_IMAGE=1",
                  "TYPE=valgrind OS=ubuntu OS_VER=20.04",
                  "TYPE=memcheck_drd OS=ubuntu OS_VER=20.04",
                  "TYPE=building OS=fedora OS_VER=32 PUSH_IMAGE=1",

--- a/utils/docker/images/install-libpmemobj-cpp.sh
+++ b/utils/docker/images/install-libpmemobj-cpp.sh
@@ -3,7 +3,7 @@
 # Copyright 2019-2021, Intel Corporation
 
 #
-# install-libpmemobj-cpp.sh <package_type>
+# install-libpmemobj-cpp.sh [package_type]
 #		- installs PMDK C++ bindings (libpmemobj-cpp)
 #
 
@@ -18,14 +18,14 @@ PREFIX="/usr"
 PACKAGE_TYPE=${1^^} #To uppercase
 echo "PACKAGE_TYPE: ${PACKAGE_TYPE}"
 
-# Merge pull request #1044 from lukaszstolarczuk/change-default-build-type; 01.03.2021
+# Merge pull request #1048 from lukaszstolarczuk/tests-gdb; 04.03.2021
 # It contains new exception: pool_invalid_argument
-LIBPMEMOBJ_CPP_VERSION="515f097bca0b3bb215ff132fcb2da948858f1f04"
+LIBPMEMOBJ_CPP_VERSION="7cc2f387fa261f370a3c5f0f9e122756bc2fffb0"
 echo "LIBPMEMOBJ_CPP_VERSION: ${LIBPMEMOBJ_CPP_VERSION}"
 
 build_dir=$(mktemp -d -t libpmemobj-cpp-XXX)
 
-git clone https://github.com/pmem/libpmemobj-cpp --shallow-since=2019-10-02 ${build_dir}
+git clone https://github.com/pmem/libpmemobj-cpp --shallow-since=2020-06-01 ${build_dir}
 
 pushd ${build_dir}
 git checkout ${LIBPMEMOBJ_CPP_VERSION}
@@ -33,7 +33,9 @@ git checkout ${LIBPMEMOBJ_CPP_VERSION}
 mkdir build
 cd build
 
-cmake .. -DCPACK_GENERATOR="${PACKAGE_TYPE}" -DCMAKE_INSTALL_PREFIX=${PREFIX}
+# turn off all redundant components
+cmake .. -DCPACK_GENERATOR="${PACKAGE_TYPE}" -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+	-DBUILD_EXAMPLES=OFF -DBUILD_TESTS=OFF -DBUILD_DOC=OFF -DBUILD_BENCHMARKS=OFF
 
 if [ "${PACKAGE_TYPE}" = "" ]; then
 	make -j$(nproc) install


### PR DESCRIPTION
- PUSH_IMAGE was set on wrong OS,
- cleanup of libpmemobj-cpp installation script, including disable installation of redundant components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/961)
<!-- Reviewable:end -->
