### PR TITLE
Fix get_all return value in robinhood engine

### DIFF
--- a/src/engines-experimental/robinhood.cc
+++ b/src/engines-experimental/robinhood.cc
@@ -552,7 +552,10 @@ status robinhood::get_all(get_kv_callback *callback, void *arg)
 
 	for (size_t i = 0; i < shards_number; ++i) {
 		shared_lock_type lock(mtxs[i]);
-		hm_rp_foreach(pmpool.handle(), container[i], callback, arg);
+		auto ret = hm_rp_foreach(pmpool.handle(), container[i], callback, arg);
+
+		if (ret)
+			return status::STOPPED_BY_CB;
 	}
 
 	return status::OK;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1727,6 +1727,11 @@ if (ENGINE_ROBINHOOD)
 			PARAMS 1000 8 8)
 
 	add_engine_test(ENGINE robinhood
+			BINARY iterate
+			TRACERS none memcheck pmemcheck
+			SCRIPT pmemobj_based/default.cmake)
+
+	add_engine_test(ENGINE robinhood
 			BINARY concurrent_put_get_remove_single_op_params
 			TRACERS none
 			SCRIPT pmemobj_based/default.cmake

--- a/tests/engine_scenarios/all/iterate.cc
+++ b/tests/engine_scenarios/all/iterate.cc
@@ -35,20 +35,19 @@ static void GetAllTest(pmem::kv::db &kv)
 	 * TEST: get_all should return all elements in db and count_all should count them
 	 * properly
 	 */
-	ASSERT_STATUS(kv.put("1", "one"), status::OK);
-	std::size_t cnt = std::numeric_limits<std::size_t>::max();
-	ASSERT_STATUS(kv.count_all(cnt), status::OK);
-	UT_ASSERT(cnt == 1);
-	cnt = std::numeric_limits<std::size_t>::max();
 
-	ASSERT_STATUS(kv.put("2", "two"), status::OK);
-	ASSERT_STATUS(kv.count_all(cnt), status::OK);
-	UT_ASSERT(cnt == 2);
-	cnt = std::numeric_limits<std::size_t>::max();
-
-	ASSERT_STATUS(kv.put("记!", "RR"), status::OK);
-	ASSERT_STATUS(kv.count_all(cnt), status::OK);
-	UT_ASSERT(cnt == 3);
+	auto entries = test_kv_list{
+		{entry_from_string("1"), entry_from_string("one")},
+		{entry_from_string("2"), entry_from_string("two")},
+		{entry_from_string("记!"), entry_from_string("RR")},
+	};
+	for (size_t i = 0; i < entries.size(); i++) {
+		auto e = entries[i];
+		ASSERT_STATUS(kv.put(e.first, e.second), status::OK);
+		std::size_t cnt = std::numeric_limits<std::size_t>::max();
+		ASSERT_STATUS(kv.count_all(cnt), status::OK);
+		UT_ASSERT(cnt == i + 1);
+	}
 
 	test_kv_list result;
 	/* get_all using string_view */
@@ -59,8 +58,7 @@ static void GetAllTest(pmem::kv::db &kv)
 	});
 	ASSERT_STATUS(s, status::OK);
 
-	auto expected = test_kv_list{{"1", "one"}, {"2", "two"}, {"记!", "RR"}};
-	UT_ASSERT((sort(result) == sort(expected)));
+	UT_ASSERT((sort(result) == sort(entries)));
 	/* get_all with non-zero exit status from callback*/
 	s = kv.get_all([&](string_view k, string_view v) { return 1; });
 	ASSERT_STATUS(s, status::STOPPED_BY_CB);
@@ -77,8 +75,7 @@ static void GetAllTest(pmem::kv::db &kv)
 		&result);
 	ASSERT_STATUS(s, status::OK);
 
-	expected = test_kv_list{{"1", "one"}, {"2", "two"}, {"记!", "RR"}};
-	UT_ASSERT((sort(result) == sort(expected)));
+	UT_ASSERT((sort(result) == sort(entries)));
 }
 
 static void test(int argc, char *argv[])


### PR DESCRIPTION
TODO: 
- [x] wait for #971 to be present on stable1.4
- [x] wait for #1009 to be merged
- [x]  Change `tests/engine_scenarios/all/iterate.cc` to use entry_from_string()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/972)
<!-- Reviewable:end -->
