### PR TITLE
Improve libpmemkv_json_config

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -110,7 +110,7 @@ public:
 					"Item with key: " + std::string(key) +
 					" has value which exceeds int64 range");
 		} else
-			throw_type_error(key, item->item_type);
+			throw_type_error(key, item->item_type, type::INT64);
 
 		return true;
 	}
@@ -138,7 +138,7 @@ public:
 				throw config_type_error(
 					"Item with key: " + std::string(key) + " is < 0");
 		} else
-			throw_type_error(key, item->item_type);
+			throw_type_error(key, item->item_type, type::UINT64);
 
 		return true;
 	}
@@ -263,20 +263,22 @@ private:
 		return &found->second;
 	}
 
-	void throw_type_error(const std::string &key, type item_type)
+	void throw_type_error(const std::string &key, type item_type, type expected_type)
 	{
-		throw config_type_error("Item with key: " + key + " is " +
-					type_names[static_cast<int>(item_type)]);
+		throw config_type_error(
+			"Item with key: " + key + " is " +
+			type_names[static_cast<int>(item_type)] +
+			". Expected: " + type_names[static_cast<int>(expected_type)]);
 	}
 
-	struct variant *get_checked_item(const char *key, type item_type)
+	struct variant *get_checked_item(const char *key, type expected_type)
 	{
 		auto item = get(key);
 		if (!item)
 			return nullptr;
 
-		if (item->item_type != item_type)
-			throw_type_error(key, item->item_type);
+		if (item->item_type != expected_type)
+			throw_type_error(key, item->item_type, expected_type);
 		return item;
 	}
 };

--- a/src/libpmemkv_json_config.cc
+++ b/src/libpmemkv_json_config.cc
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019, Intel Corporation */
+/* Copyright 2019-2021, Intel Corporation */
 
 #include "libpmemkv_json_config.h"
 #include "out.h"
@@ -30,7 +30,8 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 					config, itr->name.GetString(), value);
 				if (status != PMEMKV_STATUS_OK)
 					throw std::runtime_error(
-						"Inserting string to the config failed");
+						"Inserting string to the config failed\n" +
+						std::string(pmemkv_errormsg()));
 			} else if (itr->value.IsInt64()) {
 				auto value = itr->value.GetInt64();
 
@@ -38,7 +39,8 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 					config, itr->name.GetString(), value);
 				if (status != PMEMKV_STATUS_OK)
 					throw std::runtime_error(
-						"Inserting int to the config failed");
+						"Inserting int to the config failed\n" +
+						std::string(pmemkv_errormsg()));
 			} else if (itr->value.IsTrue() || itr->value.IsFalse()) {
 				auto value = itr->value.GetBool();
 
@@ -46,7 +48,8 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 					config, itr->name.GetString(), value);
 				if (status != PMEMKV_STATUS_OK)
 					throw std::runtime_error(
-						"Inserting bool to the config failed");
+						"Inserting bool to the config failed\n" +
+						std::string(pmemkv_errormsg()));
 			} else if (itr->value.IsObject()) {
 				rapidjson::StringBuffer sb;
 				rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
@@ -64,7 +67,9 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 				if (status != PMEMKV_STATUS_OK) {
 					pmemkv_config_delete(sub_cfg);
 					throw std::runtime_error(
-						"Cannot parse subconfig");
+						"Cannot parse subconfig\n" +
+						std::string(
+							pmemkv_config_from_json_errormsg()));
 				}
 
 				status = pmemkv_config_put_object(
@@ -72,7 +77,8 @@ int pmemkv_config_from_json(pmemkv_config *config, const char *json)
 					(void (*)(void *)) & pmemkv_config_delete);
 				if (status != PMEMKV_STATUS_OK)
 					throw std::runtime_error(
-						"Inserting a new entry to the config failed");
+						"Inserting a new entry to the config failed\n" +
+						std::string(pmemkv_errormsg()));
 			} else {
 				static std::string kTypeNames[] = {
 					"Null",	 "False",  "True",  "Object",


### PR DESCRIPTION
with extended error messages and extend the test cases for this library.

with the proposed approach we return the actual problem (which may be returned from pmemkv), next to the previous error message, like:
```
[pmemkv_config_from_json] Inserting string to the config failed
[pmemkv_config_put_string] Item with key: path already exists
````