### PR TITLE
fix: return correct result in csmap::csmap_iterator<true>::key()

### DIFF
--- a/src/engines-experimental/csmap.cc
+++ b/src/engines-experimental/csmap.cc
@@ -421,7 +421,7 @@ result<string_view> csmap::csmap_iterator<true>::key()
 {
 	assert(it_ != container->end());
 
-	return {it_->first.cdata()};
+	return {string_view(it_->first.data(), it_->first.length())};
 }
 
 result<pmem::obj::slice<const char *>> csmap::csmap_iterator<true>::read_range(size_t pos,


### PR DESCRIPTION
csamp provides binary-safe API but the return value of csmap::csmap_iterator<true>::key() is wrong if the key contains '\0'. fixing the issue by setting return string_view manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/1005)
<!-- Reviewable:end -->
