### PR TITLE
[gh-pages] add 'reports' sub-section with initial performance measurements

### DIFF
--- a/index.md
+++ b/index.md
@@ -50,6 +50,10 @@ Each of bindings has its own detailed API documentation on pmem.io:
 or just a readme (on GitHub's repository page):
 * **pmemkv-ruby** [readme](https://github.com/pmem/pmemkv-ruby)
 
+## Performance reports
+
+Available performance measurements can be found in ['reports' sub-section](./reports.html).
+
 ## Blog entries
 
 The following blog articles relates to **pmemkv**:

--- a/reports.md
+++ b/reports.md
@@ -1,0 +1,15 @@
+---
+title: Performance reports
+layout: main
+---
+
+# Performance reports
+
+We've executed benchmarks to get an idea of the results' approximate order of magnitude.
+For most cases we used [pmemkv-bench](https://github.com/pmem/pmemkv-bench/)
+benchmark, based on leveldb's *db_bench*.
+
+See each individual pdf report for Hardware, OS, Software, benchmarks, etc. details.
+
+Currently available reports:
+* [Intel&reg; Xeon&reg; Platinum 8280L + Ubuntu 20.04 kernel 5.4](https://github.com/pmem/pmemkv/releases/download/1.4/kv_2021_Apr_performance_Xeon_Ubuntu20.04.pdf)


### PR DESCRIPTION
Preview:
https://lukaszstolarczuk.github.io/pmemkv/#performance-reports

// the external storage space is just too long waiting time, so for now we publish this one into GH; later on, we move on to the new storage place (I hope 😸 )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/1048)
<!-- Reviewable:end -->
