### PR TITLE
tests: use sizeof on type, not on pointer

### DIFF
--- a/tests/config/config_c.c
+++ b/tests/config/config_c.c
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BSD-3-Clause
-/* Copyright 2019-2021, Intel Corporation */
+/* Copyright 2019-2022, Intel Corporation */
 
 #include "unittest.h"
 
@@ -18,6 +18,7 @@ static const uint64_t SIZE = 0xDEADBEEF;
 struct custom_type {
 	int a;
 	char b;
+	int extra_padding[1];
 };
 
 struct custom_type_wrapper {
@@ -111,7 +112,7 @@ static void simple_test()
 	ret = pmemkv_config_get_data(config, "object", (const void **)&value_custom,
 				     &value_custom_size);
 	UT_ASSERTeq(ret, PMEMKV_STATUS_OK);
-	UT_ASSERTeq(value_custom_size, sizeof(value_custom));
+	UT_ASSERTeq(value_custom_size, sizeof(*value_custom));
 	UT_ASSERTeq(value_custom->a, INIT_VAL);
 	UT_ASSERTeq(value_custom->b, INIT_VAL);
 


### PR DESCRIPTION
Found by Klocwork with message:

sizeof should be use on type and not on a pointer. Retrive sizeof
const is usually a developer error that uses the size of the
pointer instead of sizing the type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/1063)
<!-- Reviewable:end -->
