### PR TITLE
CI: rename 'gh-pages' branch to 'docs'

### DIFF
--- a/doc/RELEASE_STEPS.md
+++ b/doc/RELEASE_STEPS.md
@@ -32,7 +32,8 @@ Publish package and make it official:
 Later, for major/minor release:
 - bump version of Docker images (build.sh, build-image.sh, push-image.sh, pull-or-rebuild-image.sh) to $VER+1 on master branch
 - add new branch in valid-branches.sh and in "doc" job definition within .github/workflows/gha.yml, on stable-$VER branch
-- once gh-pages branch contains new documentation:
+<!-- XXX: re-write this paragraph when transition to pmem.io is done -->
+- once 'docs' branch contains new documentation:
   - add there (in index.md) new links to manpages and Doxygen docs
   - update there "Releases' support status" table (update any other release's status if needed)
   - add new docs' links in README.md on **master** branch

--- a/utils/docker/run-doc-update.sh
+++ b/utils/docker/run-doc-update.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2018-2021, Intel Corporation
+# Copyright 2018-2022, Intel Corporation
 
 #
 # run-doc-update.sh - is called inside a Docker container,
-#                     build docs and automatically update manpages
-#                     and doxygen files on gh-pages
+#		to build docs for 'valid branches' and to create a pull request
+#		with an update of doxygen and manpage files (on 'docs' branch).
 #
 
 set -e
@@ -54,9 +54,9 @@ cp -r ${REPO_DIR}/build/doc/cpp_html ${ARTIFACTS_DIR}/
 
 cd ${REPO_DIR}
 
-# Checkout gh-pages and copy docs
-GH_PAGES_NAME="gh-pages-for-${TARGET_BRANCH}"
-git checkout -B ${GH_PAGES_NAME} upstream/gh-pages
+# Checkout 'docs' and copy generated documentation
+DOCS_BRANCH_NAME="${TARGET_DOCS_DIR}-docs-update"
+git checkout -B ${DOCS_BRANCH_NAME} upstream/docs
 git clean -dfx
 
 # Clean old content, since some files might have been deleted
@@ -77,11 +77,12 @@ sed -i 's/^title:\ _MP(*\([A-Za-z_-]*\).*$/title:\ \1/g' ./${VERSION}/manpages/*
 # In that case we want to force push anyway (there might be open pull request with
 # changes which were reverted).
 git add -A
-git commit -m "doc: automatic gh-pages docs update" && true
-git push -f ${ORIGIN} ${GH_PAGES_NAME}
+git commit -m "doc: automatic docs update for ${TARGET_BRANCH}" && true
+git push -f ${ORIGIN} ${DOCS_BRANCH_NAME}
 
 # Makes pull request.
 # When there is already an open PR or there are no changes an error is thrown, which we ignore.
-hub pull-request -f -b ${DOC_REPO_OWNER}:gh-pages -h ${BOT_NAME}:${GH_PAGES_NAME} -m "doc: automatic gh-pages docs update" && true
+hub pull-request -f -b ${DOC_REPO_OWNER}:docs -h ${BOT_NAME}:${DOCS_BRANCH_NAME} \
+	-m "doc: automatic docs update for ${TARGET_BRANCH}" && true
 
 popd


### PR DESCRIPTION
We've begun the process of moving the gh-pages content - generated docs -
into pmem/pmem.github.io repository. It's now required to remove gh-pages
branch here because its content conflicts with pmem.github.io's content.

// this commit is cherry-picked from master branch; we have to apply this patch on all branches, otherwise, our stable branches (after PR merges) won't be green 😉

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/1067)
<!-- Reviewable:end -->
