### PR TITLE
CI: disable stree in engines' single build verification

### DIFF
--- a/utils/docker/run-test-building.sh
+++ b/utils/docker/run-test-building.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright 2019-2021, Intel Corporation
+# Copyright 2019-2022, Intel Corporation
 
 #
 # run-test-building.sh - is called inside a Docker container,
@@ -171,6 +171,7 @@ do
 		-DENGINE_VCMAP=OFF \
 		-DENGINE_CMAP=OFF \
 		-DENGINE_CSMAP=OFF \
+		-DENGINE_STREE=OFF \
 		-DBUILD_JSON_CONFIG=${BUILD_JSON_CONFIG} \
 		-D${engine_flag}=ON
 	make -j$(nproc)


### PR DESCRIPTION
in 'run-test-building.sh'.

Since 953893dfbf782be88f96e30d6135d452c3ba7492 we have stree engine
enabled by default and in this verification we should disable it,
so each engine is built separately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmemkv/1083)
<!-- Reviewable:end -->
